### PR TITLE
Spesialhåndtering av brukere som hører til NAV Utland

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/oppgave/enhet/Enhet.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/enhet/Enhet.kt
@@ -3,5 +3,7 @@ package no.nav.aap.oppgave.enhet
 enum class Enhet(val kode: String) {
     NAV_VIKAFOSSEN("2103"),
     NAY("4491"),
-    NAY_EGNE_ANSATTE("4483")
+    NAY_EGNE_ANSATTE("4483"),
+    NAV_UTLAND("0393"),
+    NAY_UTLAND("4402"),
 }

--- a/app/src/main/kotlin/no/nav/aap/oppgave/enhet/EnhetService.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/enhet/EnhetService.kt
@@ -70,17 +70,17 @@ class EnhetService(
             return enhet
         }
 
-        // Hvis enheten er NAV-Utland, så skal også kvalitetssikrer være NAV-Utland
-        // Dette er et unntak fra hovedregel om at vi skal bruke overordnet enhet fra NORG
-        // og må derfor spesialhåndteres
-        if (enhet.enhet == Enhet.NAV_UTLAND.kode) {
-            return EnhetForOppgave(
-                enhet = Enhet.NAV_UTLAND.kode,
-                oppfølgingsenhet = Enhet.NAV_UTLAND.kode
-            )
-        }
-
         if (unleashService.isEnabled(FeatureToggles.FylkesenhetFraNorgFeature)) {
+            // Hvis enheten er NAV-Utland, så skal også kvalitetssikrer være NAV-Utland
+            // Dette er et unntak fra hovedregel om at vi skal bruke overordnet enhet fra NORG
+            // og må derfor spesialhåndteres
+            if (enhet.enhet == Enhet.NAV_UTLAND.kode) {
+                return EnhetForOppgave(
+                    enhet = Enhet.NAV_UTLAND.kode,
+                    oppfølgingsenhet = enhet.oppfølgingsenhet?.let { norgKlient.hentOverordnetFylkesenhet(it) }
+                )
+            }
+
             return EnhetForOppgave(
                 enhet = norgKlient.hentOverordnetFylkesenhet(enhet.enhet),
                 oppfølgingsenhet = enhet.oppfølgingsenhet?.let { norgKlient.hentOverordnetFylkesenhet(it) }

--- a/app/src/test/kotlin/no/nav/aap/oppgave/enhet/EnhetServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/oppgave/enhet/EnhetServiceTest.kt
@@ -121,7 +121,7 @@ class EnhetServiceTest {
             )
         )
         val norgKlient = NorgKlientMock.medRespons(responsEnhet = (egneAnsatteOslo))
-        val nomKlient = NomKlientMock.medRespons(erEgenansatt = true)
+        val nomKlient = NomKlientMock.medRespons(erEgenansatt = false)
 
 
         val service = EnhetService(graphClient, pdlKlient, nomKlient, norgKlient, veilarbarenaKlient, unleashServiceMock)
@@ -141,6 +141,66 @@ class EnhetServiceTest {
         val service = EnhetService(graphClient, pdlKlient, nomKlient, NorgKlientMock(), veilarbarenaKlient, unleashServiceMock)
         val res = service.utledEnhetForOppgave(NAY_AVKLARINGSBEHOVKODE, "any")
         assertThat(res.enhet).isEqualTo(Enhet.NAV_VIKAFOSSEN.kode)
+    }
+
+    @Test
+    fun `Skal sette veileders enhet til NAV_UTLAND for saker knyttet til brukere fra Danmark`() {
+        val pdlKlient = PdlKlientMock.medRespons(
+            PdlData(
+                hentPerson = HentPersonResult(adressebeskyttelse = listOf(Gradering(Adressebeskyttelseskode.UGRADERT))),
+                hentGeografiskTilknytning = GeografiskTilknytning(
+                    gtType = GeografiskTilknytningType.UTLAND,
+                    gtLand = "DNK"
+                )
+            )
+        )
+
+        val norgKlient = NorgKlientMock.medRespons()
+
+        val service = EnhetService(graphClient, pdlKlient, nomKlient, norgKlient, veilarbarenaKlient, unleashServiceMock)
+        val res = service.utledEnhetForOppgave(VEILEDER_AVKLARINGSBEHOVKODE, "any")
+
+        assertThat(res.enhet).isEqualTo(Enhet.NAV_UTLAND.kode)
+    }
+
+    @Test
+    fun `Skal sette kvalitetssikrers enhet til NAV_UTLAND for saker knyttet til brukere fra Danmark`() {
+        val pdlKlient = PdlKlientMock.medRespons(
+            PdlData(
+                hentPerson = HentPersonResult(adressebeskyttelse = listOf(Gradering(Adressebeskyttelseskode.UGRADERT))),
+                hentGeografiskTilknytning = GeografiskTilknytning(
+                    gtType = GeografiskTilknytningType.UTLAND,
+                    gtLand = "DNK"
+                )
+            )
+        )
+
+        val norgKlient = NorgKlientMock.medRespons()
+
+        val service = EnhetService(graphClient, pdlKlient, nomKlient, norgKlient, veilarbarenaKlient, unleashServiceMock)
+        val res = service.utledEnhetForOppgave(KVALITETSSIKRER_AVKLARINGSBEHOVKODE, "any")
+
+        assertThat(res.enhet).isEqualTo(Enhet.NAV_UTLAND.kode)
+    }
+
+    @Test
+    fun `Skal sette NAYs enhet til NAY_UTLAND for saker knyttet til brukere fra Danmark`() {
+        val pdlKlient = PdlKlientMock.medRespons(
+            PdlData(
+                hentPerson = HentPersonResult(adressebeskyttelse = listOf(Gradering(Adressebeskyttelseskode.UGRADERT))),
+                hentGeografiskTilknytning = GeografiskTilknytning(
+                    gtType = GeografiskTilknytningType.UTLAND,
+                    gtLand = "DNK"
+                )
+            )
+        )
+
+        val norgKlient = NorgKlientMock.medRespons()
+
+        val service = EnhetService(graphClient, pdlKlient, nomKlient, norgKlient, veilarbarenaKlient, unleashServiceMock)
+        val res = service.utledEnhetForOppgave(NAY_AVKLARINGSBEHOVKODE, "any")
+
+        assertThat(res.enhet).isEqualTo(Enhet.NAY_UTLAND.kode)
     }
 
     companion object {


### PR DESCRIPTION
Brukere som tilhører NAV Utland må spesialhåndteres da vi ikke kan spørre NORG om disse. Disse skal håndteres av NAV Utland både for veileder og 2-trinns kvalitetssikring. Disse brukerene skal også rutes til et eget NAY-kontor. 