### PR TITLE
AAP-927 Filtrer bort kode 7-oppgaver fra oppgaveliste hvis saksbehandler mangler tilgang

### DIFF
--- a/api-kontrakt/src/main/kotlin/no/nav/aap/oppgave/OppgaveDto.kt
+++ b/api-kontrakt/src/main/kotlin/no/nav/aap/oppgave/OppgaveDto.kt
@@ -34,7 +34,8 @@ data class OppgaveDto(
     val opprettetTidspunkt: LocalDateTime,
     val endretAv: String? = null,
     val endretTidspunkt: LocalDateTime? = null,
-    val versjon: Long = 0
+    val versjon: Long = 0,
+    val harFortroligAdresse: Boolean? = false
 ) {
     init {
         if (journalpostId == null) {

--- a/app/src/main/kotlin/no/nav/aap/oppgave/enhet/EnhetService.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/enhet/EnhetService.kt
@@ -28,6 +28,7 @@ data class EnhetForOppgave(
 interface IEnhetService {
     fun hentEnheter(currentToken: String, ident: String): List<String>
     fun utledEnhetForOppgave(avklaringsbehovKode: AvklaringsbehovKode, fnr: String?): EnhetForOppgave
+    fun harFortroligAdresse(personIdent: String?): Boolean
 }
 
 class EnhetService(
@@ -58,6 +59,17 @@ class EnhetService(
                 finnEnhetstilknytningForPerson(fnr)
             }
         }
+    }
+
+    override fun harFortroligAdresse(personIdent: String?): Boolean {
+        return finnTilknytningOgSkjerming(personIdent).diskresjonskode == Diskresjonskode.SPFO
+    }
+
+    fun kanSaksbehandleFortroligAdresse(
+        currentToken: String
+    ): Boolean {
+        return msGraphClient.hentFortroligAdresseGruppe(currentToken).groups
+            .map { it.name }.contains(FORTROLIG_ADRESSE_GROUP)
     }
 
     private fun finnFylkesEnhet(fnr: String?): EnhetForOppgave {
@@ -196,10 +208,6 @@ class EnhetService(
             }
         }
 
-    private fun parseFylkeskontor(enhet: String): String {
-        return enhet.substring(0, 2) + "00"
-    }
-
     private fun erEgneAnsatteKontor(enhet: String): Boolean {
         return enhet.endsWith("83")
     }
@@ -207,6 +215,7 @@ class EnhetService(
 
     companion object {
         const val ENHET_GROUP_PREFIX = "0000-GA-ENHET_"
+        const val FORTROLIG_ADRESSE_GROUP = "0000-GA-Fortrolig_Adresse"
     }
 
 }

--- a/app/src/main/kotlin/no/nav/aap/oppgave/klienter/msgraph/MsGraphClient.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/klienter/msgraph/MsGraphClient.kt
@@ -15,6 +15,7 @@ import java.util.*
 
 interface IMsGraphClient {
     fun hentEnhetsgrupper(currentToken: String, ident: String): MemberOf
+    fun hentFortroligAdresseGruppe(currentToken: String): MemberOf
 }
 
 class MsGraphClient(
@@ -44,13 +45,26 @@ class MsGraphClient(
         return respons
     }
 
+    override fun hentFortroligAdresseGruppe(currentToken: String): MemberOf {
+        val url =
+            baseUrl.resolve("me/memberOf?\$count=true&\$top=1&\$filter=${starterMedFilter(FORTROLIG_ADRESSE_GROUP)}")
+        val respons = httpClient.get<MemberOf>(
+            url,
+            GetRequest(
+                currentToken = OidcToken(currentToken),
+                additionalHeaders = listOf(Header("ConsistencyLevel", "eventual"))
+            )
+        ) ?: MemberOf()
+        return respons
+    }
+
     private fun starterMedFilter(prefix: String): String {
         return "startswith(displayName,\'$prefix\')"
     }
 
     companion object {
-        private const val MSGRAPH_PREFIX = "msgraph"
         const val ENHET_GROUP_PREFIX = "0000-GA-ENHET_"
+        const val FORTROLIG_ADRESSE_GROUP = "0000-GA-Fortrolig_Adresse"
     }
 }
 

--- a/app/src/main/kotlin/no/nav/aap/oppgave/oppdater/OppdaterOppgaveService.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/oppdater/OppdaterOppgaveService.kt
@@ -197,7 +197,7 @@ class OppdaterOppgaveService(
             } else {
                 null
             }
-
+            val harFortroligAdresse = enhetService.harFortroligAdresse(oppgaveOppdatering.personIdent)
             val nyOppgave = oppgaveOppdatering.opprettNyOppgave(
                 personIdent = oppgaveOppdatering.personIdent,
                 avklaringsbehovKode = avklaringsbehovHendelse.avklaringsbehovKode,
@@ -209,7 +209,8 @@ class OppdaterOppgaveService(
                 påVentTil = oppgaveOppdatering.venteInformasjon?.frist,
                 påVentÅrsak = oppgaveOppdatering.venteInformasjon?.årsakTilSattPåVent,
                 venteBegrunnelse = oppgaveOppdatering.venteInformasjon?.begrunnelse,
-                årsakerTilBehandling = oppgaveOppdatering.årsakerTilBehandling
+                årsakerTilBehandling = oppgaveOppdatering.årsakerTilBehandling,
+                harFortroligAdresse = harFortroligAdresse,
             )
             val oppgaveId = oppgaveRepository.opprettOppgave(nyOppgave)
             log.info("Ny oppgave(id=${oppgaveId.id}) ble opprettet med status ${avklaringsbehovHendelse.status} for avklaringsbehov ${avklaringsbehovHendelse.avklaringsbehovKode}. Saksnummer: ${oppgaveOppdatering.saksnummer}. Venteinformasjon: ${oppgaveOppdatering.venteInformasjon?.årsakTilSattPåVent}")
@@ -303,7 +304,8 @@ class OppdaterOppgaveService(
         påVentTil: LocalDate?,
         påVentÅrsak: String?,
         venteBegrunnelse: String?,
-        årsakerTilBehandling: List<String>
+        årsakerTilBehandling: List<String>,
+        harFortroligAdresse: Boolean,
     ): OppgaveDto {
         return OppgaveDto(
             personIdent = personIdent,
@@ -321,7 +323,8 @@ class OppdaterOppgaveService(
             påVentTil = påVentTil,
             påVentÅrsak = påVentÅrsak,
             venteBegrunnelse = venteBegrunnelse,
-            årsakerTilBehandling = årsakerTilBehandling
+            årsakerTilBehandling = årsakerTilBehandling,
+            harFortroligAdresse = harFortroligAdresse,
         )
     }
 

--- a/app/src/test/kotlin/no/nav/aap/oppgave/enhet/EnhetServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/oppgave/enhet/EnhetServiceTest.kt
@@ -234,6 +234,9 @@ class EnhetServiceTest {
                 )
             }
 
+            override fun hentFortroligAdresseGruppe(currentToken: String): MemberOf {
+                return MemberOf()
+            }
         }
 
         val nomKlient = object : INomKlient {

--- a/app/src/test/kotlin/no/nav/aap/oppgave/oppdater/OppdaterOppgaveServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/oppgave/oppdater/OppdaterOppgaveServiceTest.kt
@@ -346,6 +346,9 @@ class OppdaterOppgaveServiceTest {
             )
         }
 
+        override fun hentFortroligAdresseGruppe(currentToken: String): MemberOf {
+            TODO("Not yet implemented")
+        }
     }
 
     val veilarbarboppfolgingKlient = object : IVeilarbarboppfolgingKlient {
@@ -362,6 +365,10 @@ class OppdaterOppgaveServiceTest {
             fnr: String?
         ): EnhetForOppgave {
             return EnhetForOppgave(ENHET_NAV_LØRENSKOG, null)
+        }
+
+        override fun harFortroligAdresse(personIdent: String?): Boolean {
+            return false
         }
     }
 }

--- a/dbflyway/src/main/resources/flyway/V1.30__lagre_fortrolig_adresse.sql
+++ b/dbflyway/src/main/resources/flyway/V1.30__lagre_fortrolig_adresse.sql
@@ -1,0 +1,2 @@
+ALTER TABLE oppgave
+    ADD COLUMN fortrolig_adresse BOOLEAN NOT NULL DEFAULT FALSE;


### PR DESCRIPTION
Lagrer ned om oppgave er kode 7 (true/false), og sjekker om saksbehandler har "fortrolig adresse"-tilgangen før oppgaver returneres i /oppgaveliste. Obs: setter default til false, så det forutsetter at vi ikke har noen kode 7-oppgaver i prod i dag


Sjekken på om bruker har kode 7 eller ikke har jeg lagt på når oppgave opprettes, og dersom tilgang blir avslått på plukk (som kan bety at bruker har fått kode 7 siden oppgaven ble opprettet). Bør den legges på noen andre steder jeg har gått glipp av?