### PR TITLE
AAP-995 Hent oppgaver som skal oppdateres kun på behandlingsref

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/oppgave/OppgaveRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/OppgaveRepository.kt
@@ -11,8 +11,6 @@ import no.nav.aap.oppgave.verdityper.Behandlingstype
 import no.nav.aap.oppgave.verdityper.Status
 import org.slf4j.LoggerFactory
 import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 import java.util.UUID
 
 private val log = LoggerFactory.getLogger(OppgaveRepository::class.java)
@@ -140,27 +138,19 @@ class OppgaveRepository(private val connection: DBConnection) {
         }
     }
 
-    fun hentOppgaver(saksnummer: String?, referanse: UUID?, journalpostId: Long?): List<OppgaveDto> {
-        val saksnummerClause = if (saksnummer != null) "SAKSNUMMER = ?" else "SAKSNUMMER IS NULL"
-        val referanseClause = if (referanse != null) "BEHANDLING_REF = ?" else "BEHANDLING_REF IS NULL"
-        val journalpostIdClause = if (journalpostId != null) "JOURNALPOST_ID = ?" else "JOURNALPOST_ID IS NULL"
+    fun hentOppgaver(referanse: UUID): List<OppgaveDto> {
         val oppgaverForReferanseQuery = """
-            SELECT 
-                $alleOppgaveFelt
-            FROM 
-                OPPGAVE 
-            WHERE 
-                $saksnummerClause AND
-                $referanseClause AND
-                $journalpostIdClause
-        """.trimIndent()
+        SELECT 
+            $alleOppgaveFelt
+        FROM 
+            OPPGAVE 
+        WHERE 
+            BEHANDLING_REF = ?
+    """.trimIndent()
 
         return connection.queryList(oppgaverForReferanseQuery) {
             setParams {
-                var index = 1
-                if (saksnummer != null) setString(index++, saksnummer)
-                if (referanse != null) setUUID(index++, referanse)
-                if (journalpostId != null) setLong(index++, journalpostId)
+                setUUID(1, referanse)
             }
             setRowMapper { row ->
                 oppgaveMapper(row)

--- a/app/src/main/kotlin/no/nav/aap/oppgave/oppdater/OppdaterOppgaveService.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/oppdater/OppdaterOppgaveService.kt
@@ -61,11 +61,7 @@ class OppdaterOppgaveService(
     private val log = LoggerFactory.getLogger(OppdaterOppgaveService::class.java)
 
     fun oppdaterOppgaver(oppgaveOppdatering: OppgaveOppdatering) {
-        val eksisterendeOppgaver = oppgaveRepository.hentOppgaver(
-            oppgaveOppdatering.saksnummer,
-            oppgaveOppdatering.referanse,
-            oppgaveOppdatering.journalpostId
-        )
+        val eksisterendeOppgaver = oppgaveRepository.hentOppgaver(referanse = oppgaveOppdatering.referanse)
 
         val oppgaveMap = eksisterendeOppgaver.associateBy({ AvklaringsbehovKode(it.avklaringsbehovKode) }, { it })
 

--- a/app/src/main/kotlin/no/nav/aap/oppgave/oppdater/OppgaveOppdatering.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/oppdater/OppgaveOppdatering.kt
@@ -37,7 +37,8 @@ enum class AvklaringsbehovStatus {
 data class OppgaveOppdatering(
     val personIdent: String? = null,
     val saksnummer: String? = null,
-    val referanse: UUID? = null,
+    // antagelse om at referanse aldri er null
+    val referanse: UUID,
     val journalpostId: Long? = null,
     val behandlingStatus: BehandlingStatus,
     val behandlingstype: Behandlingstype,


### PR DESCRIPTION
Mulig fiks på bug i postmottak, der oppgaver på avklaringsbehov "avklar sak" aldri lukkes.

Med antagelse om at behandlingsreferanse aldri er null, hent oppgaver som skal oppdateres kun på behandlingsreferanse, slik at det ikke har noe å si om saksnummer settes underveis i hendelsene som kommer fra postmottak.

Om det er tilfeller hvor behandlingsreferanse kan være null funker ikke dette.

Må også hente saksnummer for oppgave på "riktig" sted, tar det i en annen PR.