### PR TITLE
Støtte for at norg av og til kan returnere mer enn 1 overordnet enhet

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/oppgave/enhet/EnhetService.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/enhet/EnhetService.kt
@@ -85,14 +85,24 @@ class EnhetService(
         if (enhet.enhet == Enhet.NAV_UTLAND.kode) {
             return EnhetForOppgave(
                 enhet = Enhet.NAV_UTLAND.kode,
-                oppfølgingsenhet = enhet.oppfølgingsenhet?.let { norgKlient.hentOverordnetFylkesenhet(it) }
+                oppfølgingsenhet = enhet.oppfølgingsenhet?.let { getOverordnetEnhet(it) }
             )
         }
 
         return EnhetForOppgave(
-            enhet = norgKlient.hentOverordnetFylkesenhet(enhet.enhet),
-            oppfølgingsenhet = enhet.oppfølgingsenhet?.let { norgKlient.hentOverordnetFylkesenhet(it) }
+            enhet = getOverordnetEnhet(enhet.enhet),
+            oppfølgingsenhet = enhet.oppfølgingsenhet?.let { getOverordnetEnhet(it) }
         )
+    }
+
+    private fun getOverordnetEnhet(enhetsnummer: String): String {
+        val enheter = norgKlient.hentOverordnetFylkesenheter(enhetsnummer)
+        val enheterMedSammeFørste2Siffer = enheter.filter { it.substring(0, 2) == enhetsnummer.substring(0, 2) }
+
+        if (enheterMedSammeFørste2Siffer.isNotEmpty()) {
+            return enheterMedSammeFørste2Siffer.first()
+        }
+        return enheter.first()
     }
 
     private fun finnEnhetstilknytningForPerson(fnr: String?): EnhetForOppgave {

--- a/app/src/main/kotlin/no/nav/aap/oppgave/klienter/msgraph/MsGraphClient.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/klienter/msgraph/MsGraphClient.kt
@@ -22,7 +22,6 @@ class MsGraphClient(
     prometheus: PrometheusMeterRegistry
 ) : IMsGraphClient {
     private val baseUrl = URI.create(requiredConfigForKey("ms.graph.base.url"))
-
     private val clientConfig = ClientConfig(
         scope = requiredConfigForKey("ms.graph.scope")
     )

--- a/app/src/main/kotlin/no/nav/aap/oppgave/klienter/norg/NorgKlient.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/klienter/norg/NorgKlient.kt
@@ -30,7 +30,7 @@ enum class Diskresjonskode { SPFO, SPSF, ANY }
 interface INorgKlient {
     fun finnEnhet(geografiskTilknyttning: String?, erNavansatt: Boolean, diskresjonskode: Diskresjonskode): String
     fun hentEnheter(): Map<String, String>
-    fun hentOverordnetFylkesenhet(enhetsnummer: String): String
+    fun hentOverordnetFylkesenheter(enhetsnummer: String): List<String>
 }
 
 class NorgKlient: INorgKlient {
@@ -75,15 +75,20 @@ class NorgKlient: INorgKlient {
         return enheter.associate { it.enhetNr to it.navn }
     }
 
-    override fun hentOverordnetFylkesenhet(enhetsnummer: String): String {
+    override fun hentOverordnetFylkesenheter(enhetsnummer: String): List<String> {
         log.info("Henter overordnet fylkesenhet for $enhetsnummer")
-        val hentOverordnetFylkesenhetUrl = url.resolve("norg2/api/v1/enhet/$enhetsnummer/overordnet?organiseringsType=FYLKE")
-        val enheter = checkNotNull(client.get<List<EnhetMedNavn>>(hentOverordnetFylkesenhetUrl, GetRequest(
-            additionalHeaders = listOf(
-                Header("Content-Type", "application/json")
+        val hentOverordnetFylkesenhetUrl =
+            url.resolve("norg2/api/v1/enhet/$enhetsnummer/overordnet?organiseringsType=FYLKE")
+        val enheter = checkNotNull(
+            client.get<List<EnhetMedNavn>>(
+                hentOverordnetFylkesenhetUrl, GetRequest(
+                    additionalHeaders = listOf(
+                        Header("Content-Type", "application/json")
+                    )
+                )
             )
-        )))
-        return enheter.single().enhetNr
-    }
+        )
 
+        return enheter.map { it.enhetNr }
+    }
 }


### PR DESCRIPTION
Forslag til løsning på feilen hvor man har en sak på et kontor som har 2 overordnede fylkesenheter. Vi forsøker da å velge den med like 2 første siffer – og om det ikke er noen så ruter vi den til den første i listen.