### PR TITLE
AAP-1156 Nytt endepunkt for å avreservere flere oppgaver basert på ID

### DIFF
--- a/api-kontrakt/src/main/kotlin/no/nav/aap/oppgave/AvreserverOppgaveDto.kt
+++ b/api-kontrakt/src/main/kotlin/no/nav/aap/oppgave/AvreserverOppgaveDto.kt
@@ -1,0 +1,5 @@
+package no.nav.aap.oppgave
+
+data class AvreserverOppgaveDto (
+    val oppgaver: List<Long>,
+)

--- a/app/src/main/kotlin/no/nav/aap/oppgave/EndreOppgaveAPI.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/EndreOppgaveAPI.kt
@@ -36,7 +36,8 @@ fun NormalOpenAPIRoute.avreserverOppgave(dataSource: DataSource, prometheus: Pro
         prometheus.httpCallCounter("avreserver-oppgaver").increment()
         val oppgaver = dataSource.transaction { connection ->
             val oppgaverSomSkalAvreserveres = dto.oppgaver.map { oppgaveId -> OppgaveRepository(connection)
-                    .hentOppgave(oppgaveId) }.filter { it.status != Status.AVSLUTTET }
+                    .hentOppgave(oppgaveId) }
+                    .filter { it.status != Status.AVSLUTTET }
                     .map { OppgaveId(requireNotNull(it.id), it.versjon) }
             val reserverOppgaveService = ReserverOppgaveService(
                 OppgaveRepository(connection),

--- a/app/src/main/kotlin/no/nav/aap/oppgave/EndreOppgaveAPI.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/EndreOppgaveAPI.kt
@@ -33,7 +33,7 @@ fun NormalOpenAPIRoute.avreserverOppgave(dataSource: DataSource, prometheus: Pro
     }
 
     route("/avreserver-oppgaver").post<Unit, List<OppgaveId>, AvreserverOppgaveDto> { _, dto ->
-        prometheus.httpCallCounter("avreserver-oppgave").increment()
+        prometheus.httpCallCounter("avreserver-oppgaver").increment()
         val oppgaver = dataSource.transaction { connection ->
             val oppgaverSomSkalAvreserveres = dto.oppgaver.map { oppgaveId -> OppgaveRepository(connection)
                     .hentOppgave(oppgaveId) }.filter { it.status != Status.AVSLUTTET }


### PR DESCRIPTION
Vi ønsker å gi mulighet til å avreservere flere oppgaver samtidig fra frontend (feks hvis saksbehandler drar på ferie). Lager nytt endepunkt som tar inn liste med oppgave-IDer, heller enn en AvklaringsbehovReferanseDto, for å avreservere.

Så vidt jeg har skjønt trenger man kun ID, og ikke feltene i AvklaringsbehovReferanseDto, for å unikt identifisere oppgaven som skal avreserveres, men si gjerne fra hvis jeg tar feil!