### PR TITLE
Del opp kall mot PDL i 1000 identer om gangen

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/oppgave/prosessering/OppdaterOppgaveEnhetJobb.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/prosessering/OppdaterOppgaveEnhetJobb.kt
@@ -28,8 +28,13 @@ class OppdaterOppgaveEnhetJobb(
             return
         }
 
-        val identerMedStrengtFortroligAdresse = PdlGraphqlKlient.withClientCredentialsRestClient()
-            .hentAdressebeskyttelseForIdenter(oppgaverForIdent.keys.toList())
+        log.info("Sjekker addressebeskyttelse for ${oppgaverForIdent.keys.size} identer, dette blir ${Math.ceilDiv(oppgaverForIdent.keys.size, 1000)} kall mot PDL.")
+        val identerMedStrengtFortroligAdresse = oppgaverForIdent.keys.toList()
+            .chunked(1000)
+            .flatMap { identBatch ->
+                PdlGraphqlKlient.withClientCredentialsRestClient()
+                    .hentAdressebeskyttelseForIdenter(identBatch)
+            }
             .filter {
                 it.person!!.adressebeskyttelse!!
                     .any { adressebeskyttelse ->


### PR DESCRIPTION
`hentAdressebeskyttelseForIdenter` støtter kun 1000 indenter om gangen, vi må derfor dele opp i flere kall hvor man spørr om 1000 per kall. Om vi får veldig mange brukere med åpne saker samtidig kan dette føre til veldig mange kall, som er et problem vi må tenke gjennom.