### PR TITLE
AAP-884 Flytt markering-typer til kontrakt

### DIFF
--- a/api-kontrakt/src/main/kotlin/no/nav/aap/oppgave/OppgaveDto.kt
+++ b/api-kontrakt/src/main/kotlin/no/nav/aap/oppgave/OppgaveDto.kt
@@ -1,5 +1,6 @@
 package no.nav.aap.oppgave
 
+import no.nav.aap.oppgave.markering.MarkeringResponse
 import no.nav.aap.oppgave.verdityper.Behandlingstype
 import no.nav.aap.oppgave.verdityper.Status
 import java.time.LocalDate
@@ -18,16 +19,6 @@ data class ReturInformasjon(
     val endretAv: String,
 )
 
-data class BehandlingMarkering(
-    val markeringType: MarkeringForBehandling,
-    val begrunnelse: String,
-    val opprettetAv: String,
-)
-
-enum class MarkeringForBehandling {
-    HASTER,
-    KREVER_SPESIALKOMPETANSE
-}
 
 enum class ÅrsakTilReturKode {
     MANGELFULL_BEGRUNNELSE,
@@ -71,7 +62,7 @@ data class OppgaveDto(
     val versjon: Long = 0,
     val harFortroligAdresse: Boolean? = false,
     val harUlesteDokumenter: Boolean? = false,
-    val markeringer: List<BehandlingMarkering> = emptyList(),
+    val markeringer: List<MarkeringResponse> = emptyList(),
 ) {
     init {
         if (journalpostId == null) {

--- a/api-kontrakt/src/main/kotlin/no/nav/aap/oppgave/markering/MarkeringDto.kt
+++ b/api-kontrakt/src/main/kotlin/no/nav/aap/oppgave/markering/MarkeringDto.kt
@@ -1,6 +1,6 @@
 package no.nav.aap.oppgave.markering
 
-import no.nav.aap.oppgave.MarkeringForBehandling
+import no.nav.aap.oppgave.verdityper.MarkeringForBehandling
 
 data class MarkeringDto(
     val type: MarkeringForBehandling,

--- a/api-kontrakt/src/main/kotlin/no/nav/aap/oppgave/markering/MarkeringResponse.kt
+++ b/api-kontrakt/src/main/kotlin/no/nav/aap/oppgave/markering/MarkeringResponse.kt
@@ -1,6 +1,6 @@
 package no.nav.aap.oppgave.markering
 
-import no.nav.aap.oppgave.MarkeringForBehandling
+import no.nav.aap.oppgave.verdityper.MarkeringForBehandling
 
 data class MarkeringResponse(
     val markeringType: MarkeringForBehandling,

--- a/api-kontrakt/src/main/kotlin/no/nav/aap/oppgave/verdityper/MarkeringForBehandling.kt
+++ b/api-kontrakt/src/main/kotlin/no/nav/aap/oppgave/verdityper/MarkeringForBehandling.kt
@@ -1,0 +1,6 @@
+package no.nav.aap.oppgave.verdityper
+
+enum class MarkeringForBehandling {
+    HASTER,
+    KREVER_SPESIALKOMPETANSE
+}

--- a/app/src/main/kotlin/no/nav/aap/oppgave/markering/BehandlingMarkering.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/markering/BehandlingMarkering.kt
@@ -1,0 +1,9 @@
+package no.nav.aap.oppgave.markering
+
+import no.nav.aap.oppgave.verdityper.MarkeringForBehandling
+
+data class BehandlingMarkering(
+    val markeringType: MarkeringForBehandling,
+    val begrunnelse: String,
+    val opprettetAv: String,
+)

--- a/app/src/main/kotlin/no/nav/aap/oppgave/markering/MarkeringAPI.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/markering/MarkeringAPI.kt
@@ -11,7 +11,6 @@ import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
 import no.nav.aap.behandlingsflyt.kontrakt.behandling.BehandlingReferanse
 import no.nav.aap.komponenter.dbconnect.transaction
 import no.nav.aap.komponenter.httpklient.auth.bruker
-import no.nav.aap.oppgave.BehandlingMarkering
 import no.nav.aap.oppgave.metrikker.httpCallCounter
 import javax.sql.DataSource
 

--- a/app/src/main/kotlin/no/nav/aap/oppgave/markering/MarkeringRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/markering/MarkeringRepository.kt
@@ -2,7 +2,6 @@ package no.nav.aap.oppgave.markering
 
 import no.nav.aap.komponenter.dbconnect.DBConnection
 import no.nav.aap.komponenter.dbconnect.Row
-import no.nav.aap.oppgave.BehandlingMarkering
 import java.util.UUID
 
 class MarkeringRepository(

--- a/app/src/main/kotlin/no/nav/aap/oppgave/oppdater/OppgaveOppdatering.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/oppdater/OppgaveOppdatering.kt
@@ -7,7 +7,6 @@ import no.nav.aap.behandlingsflyt.kontrakt.hendelse.EndringDTO
 import no.nav.aap.behandlingsflyt.kontrakt.hendelse.MottattDokumentDto
 import no.nav.aap.behandlingsflyt.kontrakt.hendelse.ÅrsakTilReturKode
 import no.nav.aap.oppgave.AvklaringsbehovKode
-import no.nav.aap.oppgave.BehandlingMarkering
 import no.nav.aap.oppgave.mottattdokument.MottattDokument
 import no.nav.aap.oppgave.unleash.FeatureToggles
 import no.nav.aap.oppgave.unleash.IUnleashService
@@ -54,7 +53,6 @@ data class OppgaveOppdatering(
     val årsakerTilBehandling: List<String>,
     val mottattDokumenter: List<MottattDokument>,
     val reserverTil: String? = null,
-    val markeringer: List<BehandlingMarkering> = emptyList()
 )
 
 data class AvklaringsbehovHendelse(

--- a/app/src/test/kotlin/no/nav/aap/oppgave/OppgaveApiTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/oppgave/OppgaveApiTest.kt
@@ -48,6 +48,7 @@ import no.nav.aap.oppgave.server.DbConfig
 import no.nav.aap.oppgave.server.initDatasource
 import no.nav.aap.oppgave.server.server
 import no.nav.aap.oppgave.verdityper.Behandlingstype
+import no.nav.aap.oppgave.verdityper.MarkeringForBehandling
 import no.nav.aap.tilgang.SaksbehandlerNasjonal
 import no.nav.aap.tilgang.SaksbehandlerOppfolging
 import org.assertj.core.api.Assertions.assertThat

--- a/app/src/test/kotlin/no/nav/aap/oppgave/markering/MarkeringRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/oppgave/markering/MarkeringRepositoryTest.kt
@@ -2,8 +2,7 @@ package no.nav.aap.oppgave.markering
 
 import no.nav.aap.komponenter.dbconnect.transaction
 import no.nav.aap.komponenter.dbtest.InitTestDatabase
-import no.nav.aap.oppgave.BehandlingMarkering
-import no.nav.aap.oppgave.MarkeringForBehandling
+import no.nav.aap.oppgave.verdityper.MarkeringForBehandling
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.util.UUID


### PR DESCRIPTION
Frontend skal ikke lenger bruke typene fra behandlingsflyt, men disse. Må være i kontrakt