### PR TITLE
Oppgaver skal ikke kunne reserveres uten tilgangskontroll til Kelvin

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/oppgave/oppdater/OppdaterOppgaveService.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/oppdater/OppdaterOppgaveService.kt
@@ -151,6 +151,7 @@ class OppdaterOppgaveService(
                 )
 
                 if (oppgaveOppdatering.venteInformasjon != null && eksisterendeOppgave.reservertAv == null) {
+                    log.info("Forsøker å reservere oppgave ${eksisterendeOppgave.oppgaveId()} til saksbehandler som satte den på vent")
                     reserverOppgave(eksisterendeOppgave, oppgaveOppdatering.venteInformasjon)
                 }
             }
@@ -223,12 +224,10 @@ class OppdaterOppgaveService(
     ) {
         val avklaringsbehovReferanse = eksisterendeOppgave.tilAvklaringsbehovReferanseDto()
         val endretAv = venteInformasjon.sattPåVentAv
-        val reserverteOppgaver =
-            reserverOppgaveService.reserverOppgaveUtenTilgangskontroll(
-                avklaringsbehovReferanse,
-                endretAv
-            )
-        log.info("Oppgave ${reserverteOppgaver.joinToString(", ")} reservert $endretAv")
+        reserverOppgaveService.reserverOppgaveUtenTilgangskontroll(
+            avklaringsbehovReferanse,
+            endretAv
+        )
     }
 
     private fun opprettOppgaver(

--- a/app/src/main/kotlin/no/nav/aap/oppgave/plukk/ReserverOppgaveService.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/plukk/ReserverOppgaveService.kt
@@ -9,6 +9,8 @@ import no.nav.aap.oppgave.prosessering.sendOppgaveStatusOppdatering
 import no.nav.aap.oppgave.statistikk.HendelseType
 import org.slf4j.LoggerFactory
 
+private const val KELVIN = "Kelvin"
+
 class ReserverOppgaveService(
     private val oppgaveRepository: OppgaveRepository,
     private val flytJobbRepository: FlytJobbRepository
@@ -57,9 +59,11 @@ class ReserverOppgaveService(
         val oppgaverSomSkalReserveres = oppgaveRepository.hentÅpneOppgaver(avklaringsbehovReferanse)
         var c = 0
         oppgaverSomSkalReserveres.forEach {
-            oppgaveRepository.reserverOppgave(it, ident, ident)
-            sendOppgaveStatusOppdatering(it, HendelseType.RESERVERT, flytJobbRepository)
-            c++
+            if (ident != KELVIN) {
+                oppgaveRepository.reserverOppgave(it, ident, ident)
+                sendOppgaveStatusOppdatering(it, HendelseType.RESERVERT, flytJobbRepository)
+                c++
+            }
         }
         log.info("Reserverte $c oppgaver uten tilgangskontroll for $ident.")
         return oppgaverSomSkalReserveres


### PR DESCRIPTION
Fikser bug der oppgaver som ble gjenåpnet og umiddelbart satt på vent ble reservert til Kelvin. Manuell sjekk på at Kelvin aldri skal kunne reservere oppgaver.