### PR TITLE
AAP-1065 Oppgavens gradering skal være den strengeste graderingen av alle identer på behandling

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/oppgave/enhet/EnhetService.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/enhet/EnhetService.kt
@@ -223,11 +223,7 @@ class EnhetService(
     private fun finnStrengesteGradering(søkersGradering: Diskresjonskode, relevanteIdenter: List<String> = emptyList()): Diskresjonskode {
         val graderingerForRelevanteIdenter = pdlGraphqlKlient.hentAdressebeskyttelseForIdenter(relevanteIdenter).hentPersonBolk?.flatMap { it.person?.adressebeskyttelse ?: emptyList() }?.map { it.gradering.tilDiskresjonskode() }
         val alleGraderinger = graderingerForRelevanteIdenter?.plus(søkersGradering) ?: listOf(søkersGradering)
-        return when {
-            Diskresjonskode.SPSF in alleGraderinger -> Diskresjonskode.SPSF
-            Diskresjonskode.SPFO in alleGraderinger -> Diskresjonskode.SPFO
-            else -> Diskresjonskode.ANY
-        }
+        return alleGraderinger.max()
     }
 
     private fun erEgneAnsatteKontor(enhet: String): Boolean {

--- a/app/src/main/kotlin/no/nav/aap/oppgave/enhet/EnhetService.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/enhet/EnhetService.kt
@@ -17,7 +17,6 @@ import no.nav.aap.oppgave.klienter.pdl.Adressebeskyttelseskode
 import no.nav.aap.oppgave.klienter.pdl.GeografiskTilknytning
 import no.nav.aap.oppgave.klienter.pdl.GeografiskTilknytningType
 import no.nav.aap.oppgave.klienter.pdl.IPdlKlient
-import no.nav.aap.oppgave.klienter.pdl.PdlData
 import no.nav.aap.oppgave.klienter.pdl.PdlGraphqlKlient
 
 data class EnhetForOppgave(
@@ -25,10 +24,16 @@ data class EnhetForOppgave(
     val oppfølgingsenhet: String?,
 )
 
+data class TilknytningOgSkjerming(
+    val geografiskTilknytning: GeografiskTilknytning?,
+    val diskresjonskode: Diskresjonskode,
+    val erNavAnsatt: Boolean
+)
+
 interface IEnhetService {
     fun hentEnheter(currentToken: String, ident: String): List<String>
-    fun utledEnhetForOppgave(avklaringsbehovKode: AvklaringsbehovKode, fnr: String?): EnhetForOppgave
-    fun harFortroligAdresse(personIdent: String?): Boolean
+    fun utledEnhetForOppgave(avklaringsbehovKode: AvklaringsbehovKode, ident: String?, relevanteIdenter: List<String>): EnhetForOppgave
+    fun skalHaFortroligAdresse(ident: String?, relevanteIdenter: List<String>): Boolean
 }
 
 class EnhetService(
@@ -45,25 +50,26 @@ class EnhetService(
 
     }
 
-    override fun utledEnhetForOppgave(avklaringsbehovKode: AvklaringsbehovKode, fnr: String?): EnhetForOppgave {
+    override fun utledEnhetForOppgave(avklaringsbehovKode: AvklaringsbehovKode, ident: String?, relevanteIdenter: List<String>): EnhetForOppgave {
         return if (avklaringsbehovKode in
             AVKLARINGSBEHOV_FOR_SAKSBEHANDLER
             + AVKLARINGSBEHOV_FOR_BESLUTTER
             + AVKLARINGSBEHOV_FOR_SAKSBEHANDLER_POSTMOTTAK
         ) {
-            requireNotNull(fnr) { "fødselsnummer trenges for utlede enhet for ikke-kvalitetssikringsoppgaver" }
-            finnNayEnhet(fnr)
+            requireNotNull(ident) { "fødselsnummer trenges for utlede enhet for ikke-kvalitetssikringsoppgaver" }
+            finnNayEnhet(ident, relevanteIdenter)
         } else {
             if (avklaringsbehovKode.kode == Definisjon.KVALITETSSIKRING.kode.name) {
-                finnFylkesEnhet(fnr)
+                finnFylkesEnhet(ident, relevanteIdenter)
             } else {
-                finnEnhetstilknytningForPerson(fnr)
+                finnEnhetstilknytningForPerson(ident, relevanteIdenter)
             }
         }
     }
 
-    override fun harFortroligAdresse(personIdent: String?): Boolean {
-        return finnTilknytningOgSkjerming(personIdent).diskresjonskode == Diskresjonskode.SPFO
+    override fun skalHaFortroligAdresse(ident: String?, relevanteIdenter: List<String>): Boolean {
+        val søkersGradering = finnTilknytningOgSkjerming(ident).diskresjonskode
+        return finnStrengesteGradering(søkersGradering, relevanteIdenter) == Diskresjonskode.SPFO
     }
 
     fun kanSaksbehandleFortroligAdresse(
@@ -73,8 +79,8 @@ class EnhetService(
             .map { it.name }.contains(FORTROLIG_ADRESSE_GROUP)
     }
 
-    private fun finnFylkesEnhet(fnr: String?): EnhetForOppgave {
-        val enhet = finnEnhetstilknytningForPerson(fnr)
+    private fun finnFylkesEnhet(ident: String?, relevanteIdenter: List<String>): EnhetForOppgave {
+        val enhet = finnEnhetstilknytningForPerson(ident, relevanteIdenter)
         if (enhet.enhet == Enhet.NAV_VIKAFOSSEN.kode || erEgneAnsatteKontor(enhet.enhet)) {
             return enhet
         }
@@ -105,8 +111,33 @@ class EnhetService(
         return enheter.first()
     }
 
-    private fun finnEnhetstilknytningForPerson(fnr: String?): EnhetForOppgave {
-        val tilknytningOgSkjerming = finnTilknytningOgSkjerming(fnr)
+    private fun finnNayEnhet(ident: String, relevanteIdenter: List<String>): EnhetForOppgave {
+        val tilknytningOgSkjerming = finnTilknytningOgSkjerming(ident)
+        val strengesteGradering = finnStrengesteGradering(tilknytningOgSkjerming.diskresjonskode, relevanteIdenter)
+
+        val erStrengtFortrolig = strengesteGradering == Diskresjonskode.SPSF
+        val geografiskTilknytning = tilknytningOgSkjerming.geografiskTilknytning
+        val erEgenAnsatt = tilknytningOgSkjerming.erNavAnsatt
+
+        val enhet = if (erStrengtFortrolig) {
+            Enhet.NAV_VIKAFOSSEN.kode
+        } else if (erEgenAnsatt) {
+            Enhet.NAY_EGNE_ANSATTE.kode
+        } else if (geografiskTilknytning?.gtType == GeografiskTilknytningType.UTLAND) {
+            Enhet.NAY_UTLAND.kode
+        } else {
+            Enhet.NAY.kode
+        }
+
+        return EnhetForOppgave(
+            enhet,
+            oppfølgingsenhet = null
+        )
+    }
+
+    private fun finnEnhetstilknytningForPerson(ident: String?, relevanteIdenter: List<String>): EnhetForOppgave {
+        val tilknytningOgSkjerming = finnTilknytningOgSkjerming(ident)
+        val strengesteGradering = finnStrengesteGradering(tilknytningOgSkjerming.diskresjonskode, relevanteIdenter)
 
         // Hvis personen er utenlandsk, så vil NORG returnere feil kontor (Den returnerer NAY-kontoret).
         // Vi må derfor hardkode inn dette som et unntak.
@@ -117,21 +148,21 @@ class EnhetService(
                 norgKlient.finnEnhet(
                     tilknytningOgSkjerming.geografiskTilknytning?.let { mapGeografiskTilknytningTilKode(it) },
                     tilknytningOgSkjerming.erNavAnsatt,
-                    tilknytningOgSkjerming.diskresjonskode
+                    strengesteGradering,
                 )
             }
         val enhetFraArena =
-            if (tilknytningOgSkjerming.diskresjonskode != Diskresjonskode.SPSF && !tilknytningOgSkjerming.erNavAnsatt) {
-                finnOppfølgingsenhet(fnr).takeIf { it != Enhet.NASJONAL_OPPFØLGINGSENHET.kode }
+            if (strengesteGradering != Diskresjonskode.SPSF && !tilknytningOgSkjerming.erNavAnsatt) {
+                finnOppfølgingsenhet(ident).takeIf { it != Enhet.NASJONAL_OPPFØLGINGSENHET.kode }
             } else {
                 null
             }
         return EnhetForOppgave(enhetFraNorg, enhetFraArena)
     }
 
-    private fun finnOppfølgingsenhet(fnr: String?): String? {
-        val enhetFraArena = if (fnr != null) {
-            veilarbarenaKlient.hentOppfølgingsenhet(fnr)
+    private fun finnOppfølgingsenhet(ident: String?): String? {
+        val enhetFraArena = if (ident != null) {
+            veilarbarenaKlient.hentOppfølgingsenhet(ident)
         } else {
             null
         }
@@ -153,19 +184,13 @@ class EnhetService(
                 geoTilknytning.gtType.name
         }
 
-    data class TilknytningOgSkjerming(
-        val geografiskTilknytning: GeografiskTilknytning?,
-        val diskresjonskode: Diskresjonskode,
-        val erNavAnsatt: Boolean
-    )
-
-    private fun finnTilknytningOgSkjerming(fnr: String?): TilknytningOgSkjerming {
-        if (fnr != null) {
-            val pdlData = pdlGraphqlKlient.hentAdressebeskyttelseOgGeolokasjon(fnr)
+    private fun finnTilknytningOgSkjerming(ident: String?): TilknytningOgSkjerming {
+        if (ident != null) {
+            val pdlData = pdlGraphqlKlient.hentAdressebeskyttelseOgGeolokasjon(ident)
             val geografiskTilknytning = pdlData.hentGeografiskTilknytning
 
             val diskresjonskode = mapDiskresjonskode(pdlData.hentPerson?.adressebeskyttelse?.map { it.gradering })
-            val egenAnsatt = nomKlient.erEgenansatt(fnr)
+            val egenAnsatt = nomKlient.erEgenansatt(ident)
             return TilknytningOgSkjerming(
                 geografiskTilknytning,
                 diskresjonskode,
@@ -180,33 +205,7 @@ class EnhetService(
         }
     }
 
-    private fun finnNayEnhet(fnr: String): EnhetForOppgave {
-        val pdlData = pdlGraphqlKlient.hentAdressebeskyttelseOgGeolokasjon(fnr)
 
-        val erStrengtFortrolig = harStrengtFortroligAdresse(pdlData)
-        val geografiskTilknytning = pdlData.hentGeografiskTilknytning
-        val erEgenAnsatt = nomKlient.erEgenansatt(fnr)
-
-        val enhet = if (erStrengtFortrolig) {
-            Enhet.NAV_VIKAFOSSEN.kode
-        } else if (erEgenAnsatt) {
-            Enhet.NAY_EGNE_ANSATTE.kode
-        } else if (geografiskTilknytning?.gtType == GeografiskTilknytningType.UTLAND) {
-            Enhet.NAY_UTLAND.kode
-        } else {
-            Enhet.NAY.kode
-        }
-
-        return EnhetForOppgave(
-            enhet,
-            oppfølgingsenhet = null
-        )
-    }
-
-    private fun harStrengtFortroligAdresse(pdlData: PdlData): Boolean {
-        val diskresjonskode = mapDiskresjonskode(pdlData.hentPerson?.adressebeskyttelse?.map { it.gradering })
-        return diskresjonskode == Diskresjonskode.SPSF
-    }
 
     private fun mapDiskresjonskode(adressebeskyttelsekoder: List<Adressebeskyttelseskode>?) =
         adressebeskyttelsekoder?.firstOrNull().let {
@@ -220,6 +219,16 @@ class EnhetService(
                 else -> Diskresjonskode.ANY
             }
         }
+
+    private fun finnStrengesteGradering(søkersGradering: Diskresjonskode, relevanteIdenter: List<String> = emptyList()): Diskresjonskode {
+        val graderingerForRelevanteIdenter = pdlGraphqlKlient.hentAdressebeskyttelseForIdenter(relevanteIdenter).hentPersonBolk?.flatMap { it.person?.adressebeskyttelse ?: emptyList() }?.map { it.gradering.tilDiskresjonskode() }
+        val alleGraderinger = graderingerForRelevanteIdenter?.plus(søkersGradering) ?: listOf(søkersGradering)
+        return when {
+            Diskresjonskode.SPSF in alleGraderinger -> Diskresjonskode.SPSF
+            Diskresjonskode.SPFO in alleGraderinger -> Diskresjonskode.SPFO
+            else -> Diskresjonskode.ANY
+        }
+    }
 
     private fun erEgneAnsatteKontor(enhet: String): Boolean {
         return enhet.endsWith("83")

--- a/app/src/main/kotlin/no/nav/aap/oppgave/klienter/norg/NorgKlient.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/klienter/norg/NorgKlient.kt
@@ -25,7 +25,7 @@ data class FinnNavenhetRequest(
     val behandlingstema: String = "ab0014"
 )
 
-enum class Diskresjonskode { SPFO, SPSF, ANY }
+enum class Diskresjonskode(val prioritet: Int) { ANY(0), SPFO(1), SPSF(2) }
 
 interface INorgKlient {
     fun finnEnhet(geografiskTilknyttning: String?, erNavansatt: Boolean, diskresjonskode: Diskresjonskode): String

--- a/app/src/main/kotlin/no/nav/aap/oppgave/klienter/pdl/PdlGraphqlKlient.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/klienter/pdl/PdlGraphqlKlient.kt
@@ -16,7 +16,7 @@ import java.net.URI
 interface IPdlKlient {
     fun hentAdressebeskyttelseOgGeolokasjon(personident: String, currentToken: OidcToken? = null): PdlData
     fun hentPersoninfoForIdenter(identer: List<String>): PdlData?
-    fun hentAdressebeskyttelseForIdenter(identer: List<String>): List<HentPersonBolkResult>
+    fun hentAdressebeskyttelseForIdenter(identer: List<String>): PdlData
 }
 
 class PdlGraphqlKlient(
@@ -56,10 +56,10 @@ class PdlGraphqlKlient(
         return response.data ?: error("Unexpected response from PDL: ${response.errors}")
     }
     
-    override fun hentAdressebeskyttelseForIdenter(identer: List<String>): List<HentPersonBolkResult> {
+    override fun hentAdressebeskyttelseForIdenter(identer: List<String>): PdlData {
         val request = PdlRequest.hentAdressebeskyttelseForIdenter(identer)
         val response = runBlocking { graphqlQuery(request) }
-        return response.data?.hentPersonBolk ?: error("Unexpected response from PDL: ${response.errors}")
+        return response.data ?: error("Unexpected response from PDL: ${response.errors}")
     }
 
     private fun graphqlQuery(query: PdlRequest, currentToken: OidcToken? = null): PdlResponse {

--- a/app/src/main/kotlin/no/nav/aap/oppgave/oppdater/OppdaterOppgaveService.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/oppdater/OppdaterOppgaveService.kt
@@ -116,7 +116,7 @@ class OppdaterOppgaveService(
         val eksisterendeOppgave = oppgaveMap[avklaringsbehov.avklaringsbehovKode]
         if (eksisterendeOppgave != null) {
             val enhetForOppgave =
-                enhetService.utledEnhetForOppgave(avklaringsbehov.avklaringsbehovKode, personIdent)
+                enhetService.utledEnhetForOppgave(avklaringsbehov.avklaringsbehovKode, personIdent, oppgaveOppdatering.relevanteIdenter)
             val veilederArbeid = if (personIdent != null) hentVeilederArbeidsoppfølging(personIdent) else null
             val veilederSykdom = if (personIdent != null) hentVeilederSykefraværoppfølging(personIdent) else null
 
@@ -124,7 +124,7 @@ class OppdaterOppgaveService(
                 gjenÅpneOppgaveEtterReturFraKvalitetssikrer(eksisterendeOppgave, avklaringsbehov)
             } else {
                 val årsakTilSattPåVent = oppgaveOppdatering.venteInformasjon?.årsakTilSattPåVent
-                val harFortroligAdresse = enhetService.harFortroligAdresse(oppgaveOppdatering.personIdent)
+                val harFortroligAdresse = enhetService.skalHaFortroligAdresse(oppgaveOppdatering.personIdent, oppgaveOppdatering.relevanteIdenter)
 
                 oppgaveRepository.oppdatereOppgave(
                     oppgaveId = eksisterendeOppgave.oppgaveId(),
@@ -238,12 +238,13 @@ class OppdaterOppgaveService(
             val personIdent = oppgaveOppdatering.personIdent
             val enhetForOppgave = enhetService.utledEnhetForOppgave(
                 avklaringsbehovHendelse.avklaringsbehovKode,
-                personIdent
+                personIdent,
+                oppgaveOppdatering.relevanteIdenter
             )
 
             val veilederArbeid = if (personIdent != null) hentVeilederArbeidsoppfølging(personIdent) else null
             val veilederSykdom = if (personIdent != null) hentVeilederSykefraværoppfølging(personIdent) else null
-            val harFortroligAdresse = enhetService.harFortroligAdresse(personIdent)
+            val harFortroligAdresse = enhetService.skalHaFortroligAdresse(personIdent, oppgaveOppdatering.relevanteIdenter)
 
             val nyOppgave = oppgaveOppdatering.opprettNyOppgave(
                 personIdent = personIdent,

--- a/app/src/main/kotlin/no/nav/aap/oppgave/oppdater/OppgaveOppdatering.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/oppdater/OppgaveOppdatering.kt
@@ -35,6 +35,7 @@ enum class AvklaringsbehovStatus {
 
 /**
  * @param reserverTil Hvis ikke-null, reserver til denne personen.
+ * @param relevanteIdenter Identer på barn lagret på behandlingen, som påvirker enhetsutledning
  */
 data class OppgaveOppdatering(
     val personIdent: String? = null,
@@ -51,6 +52,7 @@ data class OppgaveOppdatering(
     val årsakTilOpprettelse: String?,
     val mottattDokumenter: List<MottattDokument>,
     val reserverTil: String? = null,
+    val relevanteIdenter: List<String> = emptyList(),
 )
 
 data class AvklaringsbehovHendelse(
@@ -89,6 +91,7 @@ fun BehandlingFlytStoppetHendelse.tilOppgaveOppdatering(): OppgaveOppdatering {
         opprettetTidspunkt = this.opprettetTidspunkt,
         avklaringsbehov = this.avklaringsbehov.tilAvklaringsbehovHendelseForBehandlingsflyt(),
         reserverTil = this.reserverTil,
+        relevanteIdenter = this.relevanteIdenterPåBehandling ?: emptyList(),
         venteInformasjon = if (this.erPåVent) {
             val ventebehov =
                 this.avklaringsbehov.filter { it.avklaringsbehovDefinisjon.erVentebehov() && it.status.erÅpent() }

--- a/app/src/main/kotlin/no/nav/aap/oppgave/plukk/PlukkOppgaveService.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/plukk/PlukkOppgaveService.kt
@@ -106,7 +106,8 @@ class PlukkOppgaveService(
         oppgaveRepo: OppgaveRepository
     ) {
         val oppgave = oppgaveRepo.hentOppgave(oppgaveId.id)
-        val harFortroligAdresse = enhetService.harFortroligAdresse(oppgave.personIdent)
+        // TODO: må spørre til behandlingsflyt for å finne ut om tilgang avslås pga. barn som har fått kode 7
+        val harFortroligAdresse = enhetService.skalHaFortroligAdresse(oppgave.personIdent, emptyList())
         if (harFortroligAdresse != (oppgave.harFortroligAdresse == true)) {
             oppgaveRepo.settFortroligAdresse(OppgaveId(oppgave.id!!, oppgave.versjon), harFortroligAdresse)
         }
@@ -122,7 +123,9 @@ class PlukkOppgaveService(
         val nyEnhet =
             enhetService.utledEnhetForOppgave(
                 AvklaringsbehovKode(oppgave.avklaringsbehovKode),
-                oppgave.personIdent
+                oppgave.personIdent,
+                // TODO: må ta hensyn til alle relevante identer på behandling - spør til pip i behandlingsflyt
+                emptyList()
             )
 
         if (nyEnhet != EnhetForOppgave(oppgave.enhet, oppgave.oppfølgingsenhet)) {

--- a/app/src/main/kotlin/no/nav/aap/oppgave/prosessering/OppdaterOppgaveEnhetJobb.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/prosessering/OppdaterOppgaveEnhetJobb.kt
@@ -33,7 +33,7 @@ class OppdaterOppgaveEnhetJobb(
             .chunked(1000)
             .flatMap { identBatch ->
                 PdlGraphqlKlient.withClientCredentialsRestClient()
-                    .hentAdressebeskyttelseForIdenter(identBatch)
+                    .hentAdressebeskyttelseForIdenter(identBatch).hentPersonBolk ?: emptyList()
             }
             .filter {
                 it.person!!.adressebeskyttelse!!

--- a/app/src/test/kotlin/no/nav/aap/oppgave/enhet/EnhetServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/oppgave/enhet/EnhetServiceTest.kt
@@ -10,6 +10,7 @@ import no.nav.aap.oppgave.klienter.nom.INomKlient
 import no.nav.aap.oppgave.klienter.norg.Diskresjonskode
 import no.nav.aap.oppgave.klienter.norg.INorgKlient
 import no.nav.aap.oppgave.klienter.pdl.Adressebeskyttelseskode
+import no.nav.aap.oppgave.klienter.pdl.Code
 import no.nav.aap.oppgave.klienter.pdl.GeografiskTilknytning
 import no.nav.aap.oppgave.klienter.pdl.GeografiskTilknytningType
 import no.nav.aap.oppgave.klienter.pdl.Gradering
@@ -17,6 +18,7 @@ import no.nav.aap.oppgave.klienter.pdl.HentPersonBolkResult
 import no.nav.aap.oppgave.klienter.pdl.HentPersonResult
 import no.nav.aap.oppgave.klienter.pdl.IPdlKlient
 import no.nav.aap.oppgave.klienter.pdl.PdlData
+import no.nav.aap.oppgave.klienter.pdl.PdlPerson
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.util.*
@@ -44,15 +46,15 @@ class EnhetServiceTest {
         val norgKlient = NorgKlientMock.medRespons(responsEnhet = ("0403"), overordnetFylkesEnheter = listOf("0400"))
         val service = EnhetService(graphClient, pdlKlient, nomKlient, norgKlient, VeilarbarenaKlientMock())
 
-        val utledetEnhetFylke = service.utledEnhetForOppgave(KVALITETSSIKRER_AVKLARINGSBEHOVKODE, "12345678910")
+        val utledetEnhetFylke = service.utledEnhetForOppgave(KVALITETSSIKRER_AVKLARINGSBEHOVKODE, "12345678910", emptyList())
         assertThat(utledetEnhetFylke).isNotNull()
         assertThat(utledetEnhetFylke.enhet).isEqualTo("0400")
 
-        val utledetEnhetLokal = service.utledEnhetForOppgave(VEILEDER_AVKLARINGSBEHOVKODE, "12345678910")
+        val utledetEnhetLokal = service.utledEnhetForOppgave(VEILEDER_AVKLARINGSBEHOVKODE, "12345678910", emptyList())
         assertThat(utledetEnhetLokal).isNotNull()
         assertThat(utledetEnhetLokal.enhet).isEqualTo("0403")
 
-        val utledetEnhetNay = service.utledEnhetForOppgave(NAY_AVKLARINGSBEHOVKODE, "12345678910")
+        val utledetEnhetNay = service.utledEnhetForOppgave(NAY_AVKLARINGSBEHOVKODE, "12345678910", emptyList())
         assertThat(utledetEnhetNay).isNotNull()
         assertThat(utledetEnhetNay.enhet).isEqualTo(Enhet.NAY.kode)
 
@@ -63,7 +65,7 @@ class EnhetServiceTest {
         val norgKlient = NorgKlientMock.medRespons(responsEnhet = ("0403"), overordnetFylkesEnheter = listOf("0400"))
         val service = EnhetService(graphClient, pdlKlient, nomKlient, norgKlient, VeilarbarenaKlientMock())
 
-        val utledetEnhet = service.utledEnhetForOppgave(KVALITETSSIKRER_AVKLARINGSBEHOVKODE, "12345678910")
+        val utledetEnhet = service.utledEnhetForOppgave(KVALITETSSIKRER_AVKLARINGSBEHOVKODE, "12345678910", emptyList())
         assertThat(utledetEnhet).isNotNull()
         assertThat(utledetEnhet.enhet).isEqualTo("0400")
         assertThat(utledetEnhet.oppfølgingsenhet).isEqualTo(null)
@@ -78,7 +80,7 @@ class EnhetServiceTest {
         
         val service = EnhetService(graphClient, pdlKlient, nomKlient, norgKlient,veilarbarenaClient)
 
-        val utledetEnhet = service.utledEnhetForOppgave(VEILEDER_AVKLARINGSBEHOVKODE, "12345678910")
+        val utledetEnhet = service.utledEnhetForOppgave(VEILEDER_AVKLARINGSBEHOVKODE, "12345678910", emptyList())
         assertThat(utledetEnhet).isNotNull()
         assertThat(utledetEnhet.enhet).isEqualTo("0403")
         assertThat(utledetEnhet.oppfølgingsenhet).isEqualTo(null)
@@ -88,7 +90,7 @@ class EnhetServiceTest {
     fun `Skal ikke prøve å omgjøre til fylkesenhet for vikafossen`() {
         val norgKlient = NorgKlientMock.medRespons(responsEnhet = (Enhet.NAV_VIKAFOSSEN.kode))
         val service = EnhetService(graphClient, pdlKlient, nomKlient, norgKlient, VeilarbarenaKlientMock())
-        val utledetEnhet = service.utledEnhetForOppgave(KVALITETSSIKRER_AVKLARINGSBEHOVKODE, "12345678911")
+        val utledetEnhet = service.utledEnhetForOppgave(KVALITETSSIKRER_AVKLARINGSBEHOVKODE, "12345678911", emptyList())
         assertThat(utledetEnhet).isNotNull()
         assertThat(utledetEnhet.enhet).isEqualTo(
             Enhet.NAV_VIKAFOSSEN.kode
@@ -113,7 +115,7 @@ class EnhetServiceTest {
         )
 
         val service = EnhetService(graphClient, pdlKlient, nomKlient, norgKlient, veilarbarenaClient)
-        val utledetEnhet = service.utledEnhetForOppgave(KVALITETSSIKRER_AVKLARINGSBEHOVKODE, "12345678911")
+        val utledetEnhet = service.utledEnhetForOppgave(KVALITETSSIKRER_AVKLARINGSBEHOVKODE, "12345678911", emptyList())
         assertThat(utledetEnhet).isNotNull()
         assertThat(utledetEnhet.enhet).isEqualTo(overordnetEnhet)
         assertThat(utledetEnhet.oppfølgingsenhet).isEqualTo(overordnetOppfolgingsenhet)
@@ -124,7 +126,7 @@ class EnhetServiceTest {
         val norgKlient = NorgKlientMock.medRespons(responsEnhet = ("0403"), overordnetFylkesEnheter = listOf("0300", "0400"))
         val service = EnhetService(graphClient, pdlKlient, nomKlient, norgKlient, VeilarbarenaKlientMock())
 
-        val utledetEnhet = service.utledEnhetForOppgave(KVALITETSSIKRER_AVKLARINGSBEHOVKODE, "12345678910")
+        val utledetEnhet = service.utledEnhetForOppgave(KVALITETSSIKRER_AVKLARINGSBEHOVKODE, "12345678910", emptyList())
         assertThat(utledetEnhet).isNotNull()
         assertThat(utledetEnhet.enhet).isEqualTo("0400")
         assertThat(utledetEnhet.oppfølgingsenhet).isEqualTo(null)
@@ -135,7 +137,7 @@ class EnhetServiceTest {
         val norgKlient = NorgKlientMock.medRespons(responsEnhet = ("0403"), overordnetFylkesEnheter = listOf("0200", "0500"))
         val service = EnhetService(graphClient, pdlKlient, nomKlient, norgKlient, VeilarbarenaKlientMock())
 
-        val utledetEnhet = service.utledEnhetForOppgave(KVALITETSSIKRER_AVKLARINGSBEHOVKODE, "12345678910")
+        val utledetEnhet = service.utledEnhetForOppgave(KVALITETSSIKRER_AVKLARINGSBEHOVKODE, "12345678910", emptyList())
         assertThat(utledetEnhet).isNotNull()
         assertThat(utledetEnhet.enhet).isEqualTo("0200")
         assertThat(utledetEnhet.oppfølgingsenhet).isEqualTo(null)
@@ -147,7 +149,7 @@ class EnhetServiceTest {
         val norgKlient = NorgKlientMock.medRespons(responsEnhet = (egneAnsatteOslo))
         val service = EnhetService(graphClient, pdlKlient, nomKlient, norgKlient, VeilarbarenaKlientMock())
 
-        val utledetEnhet = service.utledEnhetForOppgave(KVALITETSSIKRER_AVKLARINGSBEHOVKODE, "12345678911")
+        val utledetEnhet = service.utledEnhetForOppgave(KVALITETSSIKRER_AVKLARINGSBEHOVKODE, "12345678911", emptyList())
         assertThat(utledetEnhet).isNotNull()
         assertThat(utledetEnhet.enhet).isEqualTo(
             egneAnsatteOslo
@@ -165,7 +167,7 @@ class EnhetServiceTest {
         val nomKlient = NomKlientMock.medRespons(erEgenansatt = true)
 
         val service = EnhetService(graphClient, pdlKlient, nomKlient, NorgKlientMock(), VeilarbarenaKlientMock())
-        val res = service.utledEnhetForOppgave(NAY_AVKLARINGSBEHOVKODE, "any")
+        val res = service.utledEnhetForOppgave(NAY_AVKLARINGSBEHOVKODE, "any", emptyList())
         assertThat(res.enhet).isEqualTo(Enhet.NAY_EGNE_ANSATTE.kode)
     }
 
@@ -182,7 +184,7 @@ class EnhetServiceTest {
 
 
         val service = EnhetService(graphClient, pdlKlient, nomKlient, norgKlient, VeilarbarenaKlientMock())
-        val res = service.utledEnhetForOppgave(VEILEDER_AVKLARINGSBEHOVKODE, "any")
+        val res = service.utledEnhetForOppgave(VEILEDER_AVKLARINGSBEHOVKODE, "any", emptyList())
         assertThat(res.enhet).isEqualTo(egneAnsatteOslo)
     }
 
@@ -199,11 +201,11 @@ class EnhetServiceTest {
         val veilarbarenaClient = VeilarbarenaKlientMock(oppfølgingsenhet = "1111")
 
         val service = EnhetService(graphClient, pdlKlient, nomKlient, norgKlient, veilarbarenaClient)
-        val res = service.utledEnhetForOppgave(VEILEDER_AVKLARINGSBEHOVKODE, "any")
+        val res = service.utledEnhetForOppgave(VEILEDER_AVKLARINGSBEHOVKODE, "any", emptyList())
         assertThat(res.enhet).isEqualTo(egneAnsatteOslo)
         assertThat(res.oppfølgingsenhet).isNull()
 
-        val res2 = service.utledEnhetForOppgave(KVALITETSSIKRER_AVKLARINGSBEHOVKODE, "any")
+        val res2 = service.utledEnhetForOppgave(KVALITETSSIKRER_AVKLARINGSBEHOVKODE, "any", emptyList())
         assertThat(res2.enhet).isEqualTo(egneAnsatteOslo)
         assertThat(res2.oppfølgingsenhet).isNull()
     }
@@ -218,7 +220,7 @@ class EnhetServiceTest {
         val nomKlient = NomKlientMock.medRespons(erEgenansatt = true)
 
         val service = EnhetService(graphClient, pdlKlient, nomKlient, NorgKlientMock(), VeilarbarenaKlientMock())
-        val res = service.utledEnhetForOppgave(NAY_AVKLARINGSBEHOVKODE, "any")
+        val res = service.utledEnhetForOppgave(NAY_AVKLARINGSBEHOVKODE, "any", emptyList())
         assertThat(res.enhet).isEqualTo(Enhet.NAV_VIKAFOSSEN.kode)
     }
 
@@ -237,7 +239,7 @@ class EnhetServiceTest {
         val norgKlient = NorgKlientMock.medRespons()
 
         val service = EnhetService(graphClient, pdlKlient, nomKlient, norgKlient, VeilarbarenaKlientMock())
-        val res = service.utledEnhetForOppgave(VEILEDER_AVKLARINGSBEHOVKODE, "any")
+        val res = service.utledEnhetForOppgave(VEILEDER_AVKLARINGSBEHOVKODE, "any", emptyList())
 
         assertThat(res.enhet).isEqualTo(Enhet.NAV_UTLAND.kode)
     }
@@ -257,7 +259,7 @@ class EnhetServiceTest {
         val norgKlient = NorgKlientMock.medRespons()
 
         val service = EnhetService(graphClient, pdlKlient, nomKlient, norgKlient, VeilarbarenaKlientMock())
-        val res = service.utledEnhetForOppgave(KVALITETSSIKRER_AVKLARINGSBEHOVKODE, "any")
+        val res = service.utledEnhetForOppgave(KVALITETSSIKRER_AVKLARINGSBEHOVKODE, "any", emptyList())
 
         assertThat(res.enhet).isEqualTo(Enhet.NAV_UTLAND.kode)
     }
@@ -277,9 +279,46 @@ class EnhetServiceTest {
         val norgKlient = NorgKlientMock.medRespons()
 
         val service = EnhetService(graphClient, pdlKlient, nomKlient, norgKlient, VeilarbarenaKlientMock())
-        val res = service.utledEnhetForOppgave(NAY_AVKLARINGSBEHOVKODE, "any")
+        val res = service.utledEnhetForOppgave(NAY_AVKLARINGSBEHOVKODE, "any", emptyList())
 
         assertThat(res.enhet).isEqualTo(Enhet.NAY_UTLAND.kode)
+    }
+
+
+    @Test
+    fun `Skal sette adressebeskyttelse når relaterte identer har adressebeskyttelse`() {
+        val pdlKlient = PdlKlientMock.medRespons(
+            PdlData(
+                hentPerson = HentPersonResult(adressebeskyttelse = listOf(Gradering(Adressebeskyttelseskode.UGRADERT))),
+                // relatert ident har strengt fortrolig adresse i PDL
+                hentPersonBolk = listOf(
+                    HentPersonBolkResult(
+                    ident = "barn",
+                    person = PdlPerson(
+                        adressebeskyttelse = listOf(Gradering(Adressebeskyttelseskode.STRENGT_FORTROLIG)),
+                        code = Code.ok,
+                        navn = emptyList(),
+                    ),
+                    code = Code.ok.name
+                ),
+                    HentPersonBolkResult(
+                        ident = "barn2",
+                        person = PdlPerson(
+                            adressebeskyttelse = listOf(Gradering(Adressebeskyttelseskode.FORTROLIG)),
+                            code = Code.ok,
+                            navn = emptyList(),
+                        ),
+                        code = Code.ok.name
+                    )    )
+            )
+        )
+
+        val norgKlient = NorgKlientMock.medRespons()
+
+        val service = EnhetService(graphClient, pdlKlient, nomKlient, norgKlient, VeilarbarenaKlientMock())
+        val res = service.utledEnhetForOppgave(NAY_AVKLARINGSBEHOVKODE, "any", emptyList())
+
+        assertThat(res.enhet).isEqualTo(Enhet.NAV_VIKAFOSSEN.kode)
     }
 
     companion object {
@@ -317,8 +356,10 @@ class EnhetServiceTest {
                 TODO("Not yet implemented")
             }
 
-            override fun hentAdressebeskyttelseForIdenter(identer: List<String>): List<HentPersonBolkResult> {
-                TODO("Not yet implemented")
+            override fun hentAdressebeskyttelseForIdenter(identer: List<String>): PdlData {
+                return PdlData(
+                    hentPersonBolk = emptyList(),
+                )
             }
         }
 
@@ -349,8 +390,8 @@ class EnhetServiceTest {
                 return pdlDataRespons ?: TODO("Not yet implemented")
             }
 
-            override fun hentAdressebeskyttelseForIdenter(identer: List<String>): List<HentPersonBolkResult> {
-                TODO("Not yet implemented")
+            override fun hentAdressebeskyttelseForIdenter(identer: List<String>): PdlData {
+                return pdlDataRespons ?: TODO("Not yet implemented")
             }
         }
 


### PR DESCRIPTION
Når barn av søker har adressebeskyttelse skal også søkers sak behandles som om den har adressebeskyttelse. Legger til logikk i enhetsutreder for å ta hensyn til det.