### PR TITLE
AAP-1065 Spør behandlingsflyt om relaterte identer på nytt når tilgang avslås på plukk

### DIFF
--- a/.nais/dev.yaml
+++ b/.nais/dev.yaml
@@ -48,3 +48,7 @@ env:
       value: http://syfooversiktsrv.teamsykefravr
     - name: INTEGRASJON_SYFO_SCOPE
       value: api://dev-gcp.teamsykefravr.syfooversiktsrv/.default
+    - name: INTEGRASJON_BEHANDLINGSFLYT_URL
+      value: http://behandlingsflyt
+    - name: INTEGRASJON_BEHANDLINGSFLYT_SCOPE
+      value: api://dev-gcp.aap.behandlingsflyt/.default

--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -83,6 +83,7 @@ spec:
       rules:
         - application: tilgang
         - application: statistikk
+        - application: behandlingsflyt
         - application: skjermede-personer-pip
           namespace: nom
         - application: veilarboppfolging

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -48,3 +48,7 @@ env:
     value: http://syfooversiktsrv.teamsykefravr
   - name: INTEGRASJON_SYFO_SCOPE
     value: api://prod-gcp.teamsykefravr.syfooversiktsrv/.default
+  - name: BEHANDLINGSFLYT_BASE_URL
+    value: http://behandlingsflyt
+  - name: BEHANDLINGSFLYT_SCOPE
+    value: api://prod-gcp.aap.behandlingsflyt/.default

--- a/app/src/main/kotlin/no/nav/aap/oppgave/klienter/behandlingsflyt/BehandlingsflytException.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/klienter/behandlingsflyt/BehandlingsflytException.kt
@@ -1,0 +1,5 @@
+package no.nav.aap.oppgave.klienter.behandlingsflyt
+
+class BehandlingsflytException(
+    message: String
+) : Exception(message)

--- a/app/src/main/kotlin/no/nav/aap/oppgave/klienter/behandlingsflyt/BehandlingsflytKlient.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/klienter/behandlingsflyt/BehandlingsflytKlient.kt
@@ -1,0 +1,34 @@
+package no.nav.aap.oppgave.klienter.behandlingsflyt
+
+import no.nav.aap.komponenter.config.requiredConfigForKey
+import no.nav.aap.komponenter.httpklient.httpclient.ClientConfig
+import no.nav.aap.komponenter.httpklient.httpclient.RestClient
+import no.nav.aap.komponenter.httpklient.httpclient.get
+import no.nav.aap.komponenter.httpklient.httpclient.request.GetRequest
+import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.azurecc.ClientCredentialsTokenProvider
+import no.nav.aap.oppgave.metrikker.prometheus
+import java.net.URI
+import java.util.UUID
+
+object BehandlingsflytKlient {
+    private val baseUrl = URI.create(requiredConfigForKey("integrasjon.behandlingsflyt.url"))
+    private val clientConfig =
+        ClientConfig(
+            scope = requiredConfigForKey("integrasjon.behandlingsflyt.scope")
+        )
+    private val httpClient =
+        RestClient.withDefaultResponseHandler(
+            config = clientConfig,
+            tokenProvider = ClientCredentialsTokenProvider,
+            prometheus = prometheus
+        )
+
+    fun hentRelevanteIdenterPåBehandling(behandlingsreferanse: UUID): List<String> {
+        val url = baseUrl.resolve("/pip/api/behandling/$behandlingsreferanse/identer")
+        val respons =
+            httpClient.get<IdenterRespons>(url, GetRequest())
+                ?: throw BehandlingsflytException("Feil ved henting av identer for behandling")
+
+        return respons.barn + respons.søker
+    }
+}

--- a/app/src/main/kotlin/no/nav/aap/oppgave/klienter/behandlingsflyt/IdenterRespons.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/klienter/behandlingsflyt/IdenterRespons.kt
@@ -1,0 +1,6 @@
+package no.nav.aap.oppgave.klienter.behandlingsflyt
+
+data class IdenterRespons(
+    val søker: List<String>,
+    val barn: List<String>
+)

--- a/app/src/main/kotlin/no/nav/aap/oppgave/plukk/PlukkAPI.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/plukk/PlukkAPI.kt
@@ -25,7 +25,6 @@ import no.nav.aap.tilgang.SaksbehandlerOppfolging
 import no.nav.aap.tilgang.authorizedPost
 import org.slf4j.LoggerFactory
 import javax.sql.DataSource
-import kotlin.jvm.javaClass
 
 private val log = LoggerFactory.getLogger("plukkApi")
 

--- a/app/src/main/kotlin/no/nav/aap/oppgave/unleash/FeatureToggle.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/unleash/FeatureToggle.kt
@@ -5,9 +5,9 @@ interface FeatureToggle {
 }
 
 enum class FeatureToggles(private val toggleKey: String) : FeatureToggle {
-    DummyFeature("DummyFeature"),
     UtvidetOppgaveFilter("UtvidetOppgaveFilter"),
-    LagreMottattDokumenter("LagreMottattDokumenter");
+    LagreMottattDokumenter("LagreMottattDokumenter"),
+    HentIdenterFraBehandlingsflyt("HentIdenterFraBehandlingsflyt");
 
     override fun key(): String = toggleKey
 }

--- a/app/src/test/kotlin/no/nav/aap/oppgave/fakes/BehandlingsflytFake.kt
+++ b/app/src/test/kotlin/no/nav/aap/oppgave/fakes/BehandlingsflytFake.kt
@@ -1,0 +1,37 @@
+package no.nav.aap.oppgave.fakes
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.jackson.jackson
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.application.log
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.plugins.statuspages.StatusPages
+import io.ktor.server.response.respond
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import kotlinx.coroutines.runBlocking
+import no.nav.aap.oppgave.klienter.behandlingsflyt.IdenterRespons
+import no.nav.aap.oppgave.server.ErrorRespons
+
+fun Application.behandlingsflytFake(fakesConfig: FakesConfig) =
+    runBlocking {
+        install(ContentNegotiation) {
+            jackson()
+        }
+        install(StatusPages) {
+            exception<Throwable> { call, cause ->
+                this@behandlingsflytFake.log.info(
+                    "BEHANDLINGSFLYT :: Ukjent feil ved kall til '{}'",
+                    call.request.local.uri,
+                    cause
+                )
+                call.respond(status = HttpStatusCode.InternalServerError, message = ErrorRespons(cause.message))
+            }
+        }
+        routing {
+            get("/pip/api/behandling/{behandlingsreferanse}/identer") {
+                call.respond(IdenterRespons(søker = emptyList(), barn = fakesConfig.relaterteIdenterPåBehandling))
+            }
+        }
+    }

--- a/app/src/test/kotlin/no/nav/aap/oppgave/fakes/Fakes.kt
+++ b/app/src/test/kotlin/no/nav/aap/oppgave/fakes/Fakes.kt
@@ -12,7 +12,8 @@ import org.slf4j.LoggerFactory
 import java.util.*
 
 data class FakesConfig(
-    var negativtSvarFraTilgangForBehandling: Set<UUID> = setOf()
+    var negativtSvarFraTilgangForBehandling: Set<UUID> = setOf(),
+    var relaterteIdenterPåBehandling: List<String> = emptyList(),
 )
 
 class Fakes(val fakesConfig: FakesConfig = FakesConfig()) : AutoCloseable, ParameterResolver,
@@ -21,6 +22,7 @@ class Fakes(val fakesConfig: FakesConfig = FakesConfig()) : AutoCloseable, Param
     private val log: Logger = LoggerFactory.getLogger(Fakes::class.java)
     private val azure = FakeServer(module = { azureFake() })
     private val tilgang = FakeServer(module = { tilgangFake(fakesConfig) })
+    private val behandlingsflyt = FakeServer(module = { behandlingsflytFake(fakesConfig) })
     private val pdl = FakeServer(module = { pdlFake() })
     private val norg = FakeServer(module = { norgFake() })
     private val nom = FakeServer(module = { nomFake() })
@@ -32,6 +34,7 @@ class Fakes(val fakesConfig: FakesConfig = FakesConfig()) : AutoCloseable, Param
     private val fakeServere = listOf(
         azure,
         tilgang,
+        behandlingsflyt,
         pdl,
         norg,
         nom,
@@ -105,14 +108,19 @@ class Fakes(val fakesConfig: FakesConfig = FakesConfig()) : AutoCloseable, Param
         // Sykefraværoppfølging
         System.setProperty("integrasjon.syfo.url", "http://localhost:${sykefravavaroppfolging.port()}")
         System.setProperty("integrasjon.syfo.scope", "scope")
-
+        // Behandlingsflyt
+        System.setProperty("integrasjon.behandlingsflyt.url", "http://localhost:${behandlingsflyt.port()}")
+        System.setProperty("integrasjon.behandlingsflyt.scope", "scope")
+        // Statistikk
+        System.setProperty("integrasjon.statistikk.url", "http://localhost:${statistikkFake.port()}")
+        System.setProperty("integrasjon.statistikk.scope", "scope")
+        // Roller
         System.setProperty("AAP_SAKSBEHANDLER_NASJONAL", "saksbehandler-rolle")
         System.setProperty("AAP_SAKSBEHANDLER_OPPFOLGING", "veileder-rolle")
         System.setProperty("AAP_KVALITETSSIKRER", "kvalitetssikrer-rolle")
         System.setProperty("AAP_BESLUTTER", "beslutter-rolle")
 
-        System.setProperty("integrasjon.statistikk.url", "http://localhost:${statistikkFake.port()}")
-        System.setProperty("integrasjon.statistikk.scope", "scope")
+
     }
 
 }


### PR DESCRIPTION
Edge case der bruker underveis i saksbehandling kan få en ident knyttet til seg som har adressebeskyttelse, som gjør at det ikke går an å plukke oppgaven. Spør til behandlingsflyt om å få alle identer knyttet til behandling før enhet utledes på nytt.