### PR TITLE
Fjerner ubrukt endepunkt for hent-oppgave

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/oppgave/oppgaveliste/HentOppgaveAPI.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/oppgaveliste/HentOppgaveAPI.kt
@@ -12,7 +12,6 @@ import no.nav.aap.behandlingsflyt.kontrakt.behandling.BehandlingReferanse
 import no.nav.aap.komponenter.dbconnect.transaction
 import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.OidcToken
 import no.nav.aap.komponenter.server.auth.token
-import no.nav.aap.oppgave.AvklaringsbehovReferanseDto
 import no.nav.aap.oppgave.OppgaveDto
 import no.nav.aap.oppgave.OppgaveRepository
 import no.nav.aap.oppgave.SøkDto
@@ -25,29 +24,6 @@ import org.slf4j.LoggerFactory
 import javax.sql.DataSource
 
 private val log = LoggerFactory.getLogger("hentOppgaveApi")
-
-/**
- * Henter en oppgave gitt en behandling knyttet til en sak i behandlingsflyt eller en journalpost i postmottak.
- */
-@Deprecated("Finner ingen bruk av denne siste 30 dager fra loggene og heller ikke i koden. Vurder å fjerne den.")
-fun NormalOpenAPIRoute.hentOppgaveApiDeprecated(
-    dataSource: DataSource,
-    prometheus: PrometheusMeterRegistry
-) = route("/hent-oppgave").post<Unit, OppgaveDto, AvklaringsbehovReferanseDto> { _, request ->
-    prometheus.httpCallCounter("/hent-oppgave").increment()
-    val oppgave =
-        dataSource.transaction(readOnly = true) { connection ->
-            OppgavelisteService(
-                OppgaveRepository(connection),
-                MarkeringRepository(connection)
-            ).hentOppgave(request)
-        }
-    if (oppgave != null) {
-        respond(oppgave.hentPersonNavnMedTilgangssjekk(token()))
-    } else {
-        respondWithStatus(HttpStatusCode.NoContent)
-    }
-}
 
 /**
  * Henter nyeste oppgave med status "OPPRETTET" gitt en behandlingsreferanse.

--- a/app/src/main/kotlin/no/nav/aap/oppgave/oppgaveliste/OppgavelisteService.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/oppgaveliste/OppgavelisteService.kt
@@ -4,7 +4,6 @@ import no.nav.aap.behandlingsflyt.kontrakt.behandling.BehandlingReferanse
 import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.OidcToken
 import no.nav.aap.komponenter.miljo.Miljø
 import no.nav.aap.komponenter.miljo.MiljøKode
-import no.nav.aap.oppgave.AvklaringsbehovReferanseDto
 import no.nav.aap.oppgave.OppgaveDto
 import no.nav.aap.oppgave.OppgaveRepository
 import no.nav.aap.oppgave.OppgaveRepository.FinnOppgaverDto
@@ -36,15 +35,6 @@ class OppgavelisteService(
             val markeringer = markeringRepository.hentMarkeringerForBehandling(behandlingRef)
             oppgave.leggPåMarkeringer(markeringer.tilDto())
         }
-    }
-
-    fun hentOppgave(avklaringsbehovReferanseDto: AvklaringsbehovReferanseDto): OppgaveDto? {
-        val oppgave = oppgaveRepository.hentOppgave(avklaringsbehovReferanseDto)
-        if (avklaringsbehovReferanseDto.referanse != null) {
-            val markeringer = markeringRepository.hentMarkeringerForBehandling(avklaringsbehovReferanseDto.referanse!!)
-            return oppgave?.leggPåMarkeringer(markeringer.tilDto())
-        }
-        return oppgave
     }
 
     fun hentAktivOppgave(behandlingReferanse: BehandlingReferanse): OppgaveDto? {

--- a/app/src/main/kotlin/no/nav/aap/oppgave/server/App.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/server/App.kt
@@ -30,23 +30,22 @@ import no.nav.aap.oppgave.filter.hentFilterApi
 import no.nav.aap.oppgave.filter.opprettEllerOppdaterFilterApi
 import no.nav.aap.oppgave.filter.slettFilterApi
 import no.nav.aap.oppgave.flyttOppgave
-import no.nav.aap.oppgave.oppgaveliste.hentOppgaveApiDeprecated
 import no.nav.aap.oppgave.klienter.msgraph.MsGraphClient
 import no.nav.aap.oppgave.markering.markeringApi
 import no.nav.aap.oppgave.metrikker.prometheus
-import no.nav.aap.oppgave.oppgaveliste.mineOppgaverApi
 import no.nav.aap.oppgave.mottattdokument.mottattDokumentApi
 import no.nav.aap.oppgave.oppdater.oppdaterBehandlingOppgaverApi
 import no.nav.aap.oppgave.oppdater.oppdaterPostmottakOppgaverApi
 import no.nav.aap.oppgave.oppgaveliste.hentOppgaveApi
+import no.nav.aap.oppgave.oppgaveliste.mineOppgaverApi
 import no.nav.aap.oppgave.oppgaveliste.oppgavelisteApi
 import no.nav.aap.oppgave.oppgaveliste.oppgavesøkApi
+import no.nav.aap.oppgave.oppgaveliste.søkApi
 import no.nav.aap.oppgave.plukk.plukkNesteApi
 import no.nav.aap.oppgave.plukk.plukkOppgaveApi
 import no.nav.aap.oppgave.produksjonsstyring.hentAntallOppgaver
 import no.nav.aap.oppgave.prosessering.OppdaterOppgaveEnhetJobb
 import no.nav.aap.oppgave.prosessering.StatistikkHendelseJobb
-import no.nav.aap.oppgave.oppgaveliste.søkApi
 import org.slf4j.LoggerFactory
 import javax.sql.DataSource
 
@@ -106,7 +105,6 @@ internal fun Application.server(dbConfig: DbConfig, prometheus: PrometheusMeterR
                 flyttOppgave(dataSource, prometheus)
                 mottattDokumentApi(dataSource, prometheus)
                 // Hent oppgave(r)
-                hentOppgaveApiDeprecated(dataSource, prometheus)
                 hentOppgaveApi(dataSource, prometheus)
                 oppgavelisteApi(dataSource, prometheus)
                 oppgavesøkApi(dataSource, prometheus)


### PR DESCRIPTION
Fant ingen bruk av endepunktet `/hent-oppgave` her: https://grafana.nav.cloud.nais.io/a/grafana-metricsdrilldown-app/drilldown?nativeHistogramMetric=1&layout=grid&filters-rule=&filters-prefix=ktor&filters-suffix=&from=now-1h&to=now&timezone=browser&var-filters=app%7C%3D%7Coppgave&var-labelsWingman=%28none%29&search_txt=&var-metrics-reducer-sort-by=default&var-ds=000000020&var-other_metric_filters=filters-prefix,prefix%7C%3D%7Cktor&metric=ktor_http_server_requests_seconds&actionView=breakdown&var-groupby=route&breakdownLayout=grid

Har deployet et nytt endepunkt på `/{referanse}/hent-oppgave` som nå er i bruk.
