### PR TITLE
AAP-1333 Søk på saksbehandlere skal ta inn liste med oppgaver

### DIFF
--- a/api-kontrakt/src/main/kotlin/no/nav/aap/oppgave/tildel/SaksbehandlerSøkRequest.kt
+++ b/api-kontrakt/src/main/kotlin/no/nav/aap/oppgave/tildel/SaksbehandlerSøkRequest.kt
@@ -2,5 +2,5 @@ package no.nav.aap.oppgave.tildel
 
 data class SaksbehandlerSøkRequest(
     val søketekst: String,
-    val oppgaveId: Long,
+    val oppgaver: List<Long>,
 )

--- a/app/src/main/kotlin/no/nav/aap/oppgave/tildel/TildelOppgaveAPI.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/tildel/TildelOppgaveAPI.kt
@@ -25,7 +25,7 @@ fun NormalOpenAPIRoute.tildelOppgaveApi(dataSource: DataSource) {
                 oppgaveRepository = OppgaveRepository(connection),
             ).søkEtterSaksbehandlere(
                 søketekst = request.søketekst,
-                oppgaveId = request.oppgaveId,
+                oppgaver = request.oppgaver,
             )
         }
 

--- a/app/src/test/kotlin/no/nav/aap/oppgave/OppgaveApiTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/oppgave/OppgaveApiTest.kt
@@ -555,7 +555,7 @@ class OppgaveApiTest {
         val oppgave = hentOppgave(referanse1)
 
         // Søk på å tildele en 11-5-oppgave skal bare returnere veiledere
-        val lokalSaksbehandlere = søkEtterSaksbehandlere("any", oppgave!!)?.saksbehandlere
+        val lokalSaksbehandlere = søkEtterSaksbehandlere("any", listOf(oppgave?.id!!))?.saksbehandlere
         assertThat(lokalSaksbehandlere).hasSize(2)
         assertThat(lokalSaksbehandlere?.mapNotNull { it.navn }?.all { it.contains("Kontorsen") }).isTrue()
 
@@ -581,10 +581,13 @@ class OppgaveApiTest {
         val oppgave2 = hentOppgave(referanse2)
 
         // Søk på å tildele en 11-19-oppgave skal bare returnere NAY-saksbehandlere
-        val naySaksbehandlere = søkEtterSaksbehandlere("any", oppgave2!!)?.saksbehandlere
+        val naySaksbehandlere = søkEtterSaksbehandlere("any", listOf(oppgave2?.id!!))?.saksbehandlere
         assertThat(naySaksbehandlere).hasSize(2)
         assertThat(naySaksbehandlere?.mapNotNull { it.navn }?.all { it.contains("Naysen") }).isTrue()
 
+        // Søk på å tildele både en NAY-oppgave og en kontor-oppgave skal vise alle veiledere
+        val alleSaksbehandlere = søkEtterSaksbehandlere("tekst", listOf(oppgave.id!!, oppgave2.id!!))?.saksbehandlere
+        assertThat(alleSaksbehandlere).hasSize(4)
     }
 
     @Test
@@ -1292,12 +1295,12 @@ class OppgaveApiTest {
         )
     }
 
-    private fun søkEtterSaksbehandlere(søketekst: String, oppgave: OppgaveDto): SaksbehandlerSøkResponse? {
+    private fun søkEtterSaksbehandlere(søketekst: String, oppgaver: List<Long>): SaksbehandlerSøkResponse? {
         return client.post(
             URI.create("http://localhost:$port/saksbehandler-sok"),
             PostRequest(body = SaksbehandlerSøkRequest(
                 søketekst = søketekst,
-                oppgaveId = oppgave.id!!,
+                oppgaver = oppgaver,
             ),
                 additionalHeaders = listOf(
                     Header("Authorization", "Bearer ${getOboToken(listOf(SaksbehandlerOppfolging.id)).token()}")


### PR DESCRIPTION
Det skal gå an å tildele flere oppgaver samtidig, må derfor utlede linje for alle for å vise riktige saksbehandlere (i praksis skal det bare være mulig å tildele oppgaver fra én linje samtidig).