### PR TITLE
AAP-1500 Send klageoppgaver til fylkeskontor for Vest-Viken

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/oppgave/unleash/FeatureToggle.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/unleash/FeatureToggle.kt
@@ -5,7 +5,8 @@ interface FeatureToggle {
 }
 
 enum class FeatureToggles(private val toggleKey: String) : FeatureToggle {
-    VarsleHvisEnhetIkkeGodkjent("VarsleHvisEnhetIkkeGodkjent");
+    VarsleHvisEnhetIkkeGodkjent("VarsleHvisEnhetIkkeGodkjent"),
+    NyRutingAvKlageoppgaver("NyRutingAvKlageoppgaver");
 
     override fun key(): String = toggleKey
 }


### PR DESCRIPTION
For alle andre fylker rutes klageoppgaver "vanlig". Kan utvides til å gjelde flere fylker ved behov.

Jeg har antatt at det kun er avklaringsbehovet VURDER_KLAGE_KONTOR (6002) som skal ha spesielle regler for ruting, og at alle andre avklaringsbehov knyttet til klage løses av NAY, med unntak av kvalitetssikrer som uansett skal til fylkeskontor.