### PR TITLE
Bugfix: Filtrering på tilbakekrevingsbeløp - skip null beløp

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/oppgave/OppgaveRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/OppgaveRepository.kt
@@ -377,11 +377,11 @@ class OppgaveRepository(private val connection: DBConnection) {
         }
 
         if(utvidetFilter.beløpMindreEnn!= null){
-            sb.append(" AND t.belop < ${utvidetFilter.beløpMindreEnn} OR t.belop IS NULL")
+            sb.append(" AND (t.belop < ${utvidetFilter.beløpMindreEnn})")
         }
 
         if (utvidetFilter.beløpMerEnn != null){
-            sb.append(" AND t.belop > ${utvidetFilter.beløpMerEnn} OR t.belop IS NULL")
+            sb.append(" AND (t.belop > ${utvidetFilter.beløpMerEnn})")
         }
 
         val returStatuserNotEmpty = utvidetFilter.returStatuser.isNotEmpty()

--- a/app/src/test/kotlin/no/nav/aap/oppgave/OppgaveRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/oppgave/OppgaveRepositoryTest.kt
@@ -730,8 +730,8 @@ class OppgaveRepositoryTest {
         assertThat(søkMedUtvidetFilterPåVent.oppgaver).hasSize(2)
         assertThat(søkMedUtvidetFilterHastesøk.oppgaver).hasSize(1)
         assertThat(søkMedUtvidetFilterVentefristUtløpt.oppgaver).hasSize(1)
-        assertThat(merEnnSøkEks.oppgaver).hasSize(6)
-        assertThat(merEnnSøkInk.oppgaver).hasSize(7)
+        assertThat(merEnnSøkEks.oppgaver).hasSize(0)
+        assertThat(merEnnSøkInk.oppgaver).hasSize(1)
     }
 
     @Test


### PR DESCRIPTION
Bugfix: Filtrering på tilbakekrevingsbeløp skal ikke tillate nullverdier i returnert oppgaveliste.