### PR TITLE
AAP-1997 feil filtrering av fom/tom i UtvidetOppgavelisteFilter 

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/oppgave/OppgaveRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/OppgaveRepository.kt
@@ -406,11 +406,11 @@ class OppgaveRepository(private val connection: DBConnection) {
         }
 
         if (utvidetFilter.fom != null) {
-            sb.append(" AND OPPRETTET_TIDSPUNKT >= '${utvidetFilter.fom}'")
+            sb.append(" AND BEHANDLING_OPPRETTET >= '${utvidetFilter.fom}'")
         }
 
         if (utvidetFilter.tom != null) {
-            sb.append(" AND OPPRETTET_TIDSPUNKT <= '${utvidetFilter.tom}'")
+            sb.append(" AND BEHANDLING_OPPRETTET <= '${utvidetFilter.tom}'")
         }
 
         if (utvidetFilter.markertHaster == true) {

--- a/app/src/test/kotlin/no/nav/aap/oppgave/OppgaveRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/oppgave/OppgaveRepositoryTest.kt
@@ -747,6 +747,32 @@ class OppgaveRepositoryTest {
     }
 
     @Test
+    fun `fom og tom i utvidet filter filtrerer på behandling opprettet`() {
+        val innenforRange = opprettOppgave(
+            enhet = ENHET_NAV_ENEBAKK,
+            behandlingOpprettet = LocalDateTime.of(2024, 1, 15, 12, 0)
+        )
+        opprettOppgave(
+            enhet = ENHET_NAV_ENEBAKK,
+            behandlingOpprettet = LocalDateTime.of(2024, 1, 9, 12, 0)
+        )
+        opprettOppgave(
+            enhet = ENHET_NAV_ENEBAKK,
+            behandlingOpprettet = LocalDateTime.of(2024, 1, 21, 12, 0)
+        )
+
+        val resultat = finnAlleOppgaverMedUtvidetFilter(
+            filter = TransientFilterDto(enheter = setOf(ENHET_NAV_ENEBAKK)),
+            utvidetOppgavelisteFilter = UtvidetOppgavelisteFilter(
+                fom = LocalDate.of(2024, 1, 10),
+                tom = LocalDate.of(2024, 1, 20)
+            ),
+        )
+
+        assertThat(resultat.oppgaver.map { it.id }).containsExactly(innenforRange.id)
+    }
+
+    @Test
     fun `beløpMerEnn filter er inklusiv - inkluderer tilbakekrevingsoppgaver med eksakt beløp`() {
         val tilbakekrevingOppgave = opprettOppgave(
             enhet = ENHET_NAV_ENEBAKK,


### PR DESCRIPTION
filtrerte tidligere på OPPRETTET_TIDSPUNKT (når oppgaven ble opprettet). Endret til å filtrere på BEHANDLING_OPPRETTET.

<img width="324" height="236" alt="image" src="https://github.com/user-attachments/assets/4a40c7f2-08c4-4a39-a5c4-ab311881fb86" />

