### PR TITLE
Bruk første tidspunkt i siste sammenhengende NAY-bolk som oversendtDato

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/oppgave/enhet/EnhetAPI.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/enhet/EnhetAPI.kt
@@ -30,7 +30,7 @@ import no.nav.aap.tilgang.AuthorizationMachineToMachineConfig
 import no.nav.aap.tilgang.Rolle
 import no.nav.aap.tilgang.authorizedPost
 import org.slf4j.LoggerFactory
-import java.util.UUID
+import java.util.*
 import javax.sql.DataSource
 
 fun NormalOpenAPIRoute.hentEnhetApi(
@@ -78,6 +78,21 @@ fun NormalOpenAPIRoute.enhetStatus(dataSource: DataSource) =
 
         respond(EnhetOgOversendelse(respons))
     }
+
+/**
+ * Returnerer første oppgave i den siste sammenhengende bolken av oppgaver fra kandidatlisten
+ * */
+private fun førsteISisteSammenhengendeBlokk(
+    alleOppgaver: List<OppgaveDto>,
+    kandidater: List<OppgaveDto>
+): OppgaveDto {
+    val kandidatSet = kandidater.toSet()
+    return alleOppgaver
+        .reversed()
+        .dropWhile { it !in kandidatSet }
+        .takeWhile { it in kandidatSet }
+        .lastOrNull() ?: kandidater.first()
+}
 
 internal fun enhetOgOversendelse(alleOppgaver: List<OppgaveDto>): NåværendeEnhet? {
     val log = LoggerFactory.getLogger("enhet-status")
@@ -186,7 +201,7 @@ internal fun enhetOgOversendelse(alleOppgaver: List<OppgaveDto>): NåværendeEnh
         }
 
         oversendtTilNay.isNotEmpty() && oversendtTilNay.any { it.erÅpen } -> {
-            val førsteOppgave = oversendtTilNay.first()
+            val førsteOppgave = førsteISisteSammenhengendeBlokk(oppgaver, oversendtTilNay)
             NåværendeEnhet(
                 oversendtDato = førsteOppgave.opprettetTidspunkt.toLocalDate(),
                 oppgaveKategori = OppgaveKategori.NAY,
@@ -198,9 +213,7 @@ internal fun enhetOgOversendelse(alleOppgaver: List<OppgaveDto>): NåværendeEnh
         }
 
         beslutter.isNotEmpty() && beslutter.any { it.erÅpen } -> {
-            val førsteOppgave =
-                oversendtTilNay.firstOrNull()
-                    ?: beslutter.first()  // oversendtDato skal fortsatt være dato behandling gikk til NAY
+            val førsteOppgave = førsteISisteSammenhengendeBlokk(oppgaver, oversendtTilNay + beslutter)
             NåværendeEnhet(
                 oversendtDato = førsteOppgave.opprettetTidspunkt.toLocalDate(),
                 oppgaveKategori = OppgaveKategori.BESLUTTER,

--- a/app/src/test/kotlin/no/nav/aap/oppgave/enhet/EnhetOgOversendelseTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/oppgave/enhet/EnhetOgOversendelseTest.kt
@@ -33,19 +33,37 @@ class EnhetOgOversendelseTest {
     }
 
     @Test
-    fun `om behandlingen går til NAY flere ganger, skal oversendelse være første tidspunkt i første bolk`() {
+    fun `om behandlingen går til NAY flere ganger, skal oversendelse være første tidspunkt i siste bolk`() {
         val oppgaver =
             listOf(
                 oppgave(Definisjon.AVKLAR_SYKDOM, "1234"),
                 oppgave(Definisjon.KVALITETSSIKRING, "1200"),
                 oppgave(Definisjon.SAMORDNING_ARBEIDSGIVER, "4491"),
                 oppgave(Definisjon.AVKLAR_SYKDOM, "1234"),
-                oppgave(Definisjon.SAMORDNING_ARBEIDSGIVER, "4491").åpen()
+                oppgave(Definisjon.SAMORDNING_ARBEIDSGIVER, "4491"),
+                oppgave(Definisjon.SAMORDNING_ARBEIDSGIVER, "4491").åpen(),
             )
 
         val res = enhetOgOversendelse(oppgaver)!!
 
-        assertThat(res.oversendtDato).isEqualTo(LocalDate.of(2022, 1, 1).plusDays(2))
+        assertThat(res.oversendtDato).isEqualTo(LocalDate.of(2022, 1, 1).plusDays(4))
+    }
+
+    @Test
+    fun `for beslutter-oppgaver, vis når saken først gikk til NAY`() {
+        val oppgaver =
+            listOf(
+                oppgave(Definisjon.AVKLAR_SYKDOM, "1234"),
+                oppgave(Definisjon.KVALITETSSIKRING, "1200"),
+                oppgave(Definisjon.SAMORDNING_ARBEIDSGIVER, "4491"),
+                oppgave(Definisjon.AVKLAR_SYKDOM, "1234"),
+                oppgave(Definisjon.SAMORDNING_ARBEIDSGIVER, "4491"),
+                oppgave(Definisjon.FATTE_VEDTAK, "4491").åpen(),
+            )
+
+        val res = enhetOgOversendelse(oppgaver)!!
+
+        assertThat(res.oversendtDato).isEqualTo(LocalDate.of(2022, 1, 1).plusDays(4))
     }
 
     private val behandlingRef = UUID.randomUUID()


### PR DESCRIPTION
## Hva er endret

For NAY- og beslutter-oppgaver skal `oversendtDato` reflektere når behandlingen **sist** kom til NAY, ikke første gang noensinne.

Dersom en behandling har vært innom NAY, tilbake til lokalkontor, og så til NAY igjen, brukes nå starten på den **siste sammenhengende bolken** med NAY-oppgaver.

## Implementasjon

- Ekstrahert felles logikk i hjelpefunksjonen `førsteISisteSammenhengendeBlokk()`
- NAY-branchen bruker kun `oversendtTilNay` som kandidater
- Beslutter-branchen bruker `oversendtTilNay + beslutter` som kandidater (slik at FATTE_VEDTAK ikke bryter bolken)

## Tester

Lagt til to nye tester i `EnhetOgOversendelseTest`:
- NAY: behandling går til NAY flere ganger → bruker første tidspunkt i siste bolk
- Beslutter: viser når saken først gikk til NAY (siste bolk)