### PR TITLE
Reserver oppgave: idempotens + ikke logg hvis versjon er endret

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/oppgave/OppgaveRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/OppgaveRepository.kt
@@ -20,6 +20,11 @@ import java.util.*
 
 private val log = LoggerFactory.getLogger(OppgaveRepository::class.java)
 
+class FeilVersjonException(
+    val oppgaveId: OppgaveId,
+    val faktiskVersjon: Long,
+): RuntimeException("Endring av $oppgaveId feilet fordi faktisk versjon er $faktiskVersjon")
+
 class OppgaveRepository(private val connection: DBConnection) {
 
     fun opprettOppgave(oppgaveDto: OppgaveDto): OppgaveId {
@@ -615,7 +620,20 @@ class OppgaveRepository(private val connection: DBConnection) {
                 setLong(4, oppgaveId.id)
                 setLong(5, oppgaveId.versjon)
             }
-            setResultValidator { require(it == 1) { "Prøvde å reservere én oppgave, men fant $it oppgaver. Oppgave: $oppgaveId" } }
+            setResultValidator { endredeRader ->
+                require(endredeRader <= 1) { "Prøvde å reservere én oppgave, men fant $endredeRader oppgaver. Oppgave: $oppgaveId" }
+
+                if (endredeRader == 0) {
+                    val lagretOppgave = hentOppgave(oppgaveId.id)
+                    if (lagretOppgave.reservertAv == reservertAvIdent && lagretOppgave.endretAv == endretAvIdent) {
+                        /* Noop / idempotent oppførsel. Oppgaven er allerede reservert riktig. Kanskje vi fikk samme request to
+                         * ganger på grunn av at bruker klikket to ganger raskt etter hverandre fordi vi har treghet i systemet?
+                         */
+                    } else {
+                        throw FeilVersjonException(oppgaveId, lagretOppgave.versjon)
+                    }
+                }
+            }
         }
     }
 

--- a/app/src/main/kotlin/no/nav/aap/oppgave/server/StatusPagesConfigHelper.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/server/StatusPagesConfigHelper.kt
@@ -11,6 +11,7 @@ import java.sql.SQLException
 import no.nav.aap.komponenter.httpklient.exception.ApiErrorCode
 import no.nav.aap.komponenter.httpklient.exception.ApiException
 import no.nav.aap.komponenter.httpklient.exception.InternfeilException
+import no.nav.aap.oppgave.FeilVersjonException
 import org.slf4j.LoggerFactory
 
 object StatusPagesConfigHelper {
@@ -46,6 +47,16 @@ object StatusPagesConfigHelper {
                     secureLogger.error("SQL-feil: ", cause)
 
                     call.respondWithError(InternfeilException("En feil oppsto. Prøv igjen om litt."))
+                }
+
+                is FeilVersjonException -> {
+                    val msg = "Endring av ${cause.oppgaveId} feilet siden faktisk versjon er ${cause.faktiskVersjon}"
+                    logger.info(msg, cause)
+                    /** Beholder observerbar adferd ved å returnere InternfeilException siden jeg ikke
+                     * har undersøkt feilhåndtering hos klienter. Ser for meg at dette er en type feil som frontend
+                     * kanskje kunne håndtert spesielt.
+                     */
+                    call.respondWithError(InternfeilException(msg))
                 }
 
                 else -> {


### PR DESCRIPTION
Oppdager hvis reservasjonen allerede er utført, og fortsetter i så fall som vanlig.

Logger ikke lenger error i oppgave hvis versjonen er feil. At versjonen er feil er en forventet adferd, men vi logger i dag 3 error-meldinger fra 3 forskjellige apper. Returnerer fortsatt samme error i HTTP-responsen.