### PR TITLE
Fjerner duplikat utsendelse av RESERVERT-hendelse

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/oppgave/oppdater/OppdaterOppgaveService.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/oppdater/OppdaterOppgaveService.kt
@@ -307,12 +307,7 @@ class OppdaterOppgaveService(
 
             log.info("Reserverer oppgave ${oppdatertOppgave.oppgaveId()} med status ${avklaringsbehov.status}")
             reserverOppgaveService.reserverOppgaveUtenTilgangskontroll(eksisterendeOppgave.behandlingRef, sistEndretAv)
-            sendOppgaveStatusOppdatering(
-                oppdatertOppgave.oppgaveId(),
-                HendelseType.RESERVERT,
-                flytJobbRepository
-            )
-
+            // sender ikke RESERVERT-hendelse til statistikk fordi reserverOppgaveUtenTilgangskontroll allerede gjør det
         } else {
             log.info("Reserverer ikke oppgave ${eksisterendeOppgave.oppgaveId()} med status ${avklaringsbehov.status} fordi $KELVIN utførte siste endring")
         }

--- a/app/src/main/kotlin/no/nav/aap/oppgave/plukk/PlukkOppgaveService.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/plukk/PlukkOppgaveService.kt
@@ -111,8 +111,7 @@ class PlukkOppgaveService(
         val oppgave = oppgaveRepository.hentOppgave(oppgaveId.id)
         if (oppgave.reservertAv == ident) {
             log.info("Avreserverer oppgave ${oppgaveId.id} etter at tilgang ble avslått på plukk.")
-            oppgaveRepository.avreserverOppgave(oppgaveId, ident)
-            sendOppgaveStatusOppdatering(oppgaveId, HendelseType.AVRESERVERT, flytJobbRepository)
+            reserverOppgaveService.avreserverOppgave(oppgaveId, ident)
         }
     }
 }


### PR DESCRIPTION
Metoden reserverOppgaveUtenTilgangskontroll oppretter samme jobb. Potensiale for forskjellig versjon på ID-en, men jobben som kjører ser ikke på ID-en, så det skal ikke ha noe å si.