### PR TITLE
Kelvin-komponenter 2.0.58 bruker ktor 3.5 som ikke spiller på lag og …

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 ktor = "3.4.3"
 jackson = "2.21.3"
-komponenter = "2.0.58"
+komponenter = "2.0.56"
 tilgang = "1.0.224"
 behandlingsflytVersjon = "0.0.613"
 postmottakVersjon = "6.0.4"


### PR DESCRIPTION
…kan være kilde til treghet. Degraderer i håp om at vi får færre timeouts / 10 sek kall