### PR TITLE
Vedlikehold: Legg til gradle task runTestAppMotBehandlingsflyt

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,10 @@ Velg konfigurasjonen `TestApp` i Run/Debug-menyen.
 
 Alternativt, kjør opp mot behandlingsflyt:
 
-```./gradlew runTestAppMotBehandlingsflyt```
+```
+docker-compose up -d
+./gradlew runTestAppMotBehandlingsflyt
+```
 
 ### Kjøre lokalt mot dev-gcp
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ Velg konfigurasjonen `TestApp` i Run/Debug-menyen.
 
 ```./gradlew runTestApp```
 
+Alternativt, kjør opp mot behandlingsflyt:
+
+```./gradlew runTestAppMotBehandlingsflyt```
+
 ### Kjøre lokalt mot dev-gcp
 
 Prosjektet inneholder en run config som kan kjøres av IntelliJ. Burde være synlig under "Run configurations" med navnet

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,6 +28,21 @@ tasks.register<JavaExec>("runTestApp") {
     )
 }
 
+tasks.register<JavaExec>("runTestAppMotBehandlingsflyt") {
+    description = "Kjør TestApp mot lokal behandlingsflyt (samme config som .run/TestApp (mot behandlingsflyt).run.xml)"
+    classpath = sourceSets.test.get().runtimeClasspath
+    mainClass.set("no.nav.aap.oppgave.server.TestAppKt")
+    environment(
+        "NAIS_CLUSTER_NAME" to "LOCAL",
+        "NAIS_DATABASE_OPPGAVE_OPPGAVE_JDBC_URL" to "jdbc:postgresql://localhost:5439/postgres",
+        "NAIS_DATABASE_OPPGAVE_OPPGAVE_USERNAME" to "postgres",
+        "NAIS_DATABASE_OPPGAVE_OPPGAVE_PASSWORD" to "",
+        "INTEGRASJON_BEHANDLINGSFLYT_URL" to "http://localhost:8080",
+        "LOKAL_BEHANDLINGSFLYT_AZURE_PORT" to "8081",
+        "HTTP_PORT" to "8084",
+    )
+}
+
 dependencies {
     implementation(project(":dbflyway"))
     implementation(project(":api-kontrakt"))


### PR DESCRIPTION
- Forenkler cli app oppstart mot aap-behandlingsflyt, tilsvarende TestApp (mot behandlingsflyt) i .run for IntelliJ + port 8084