### PR TITLE
AAP-1862 - Bugfix. Påvent kun for oppgaver hos saksbehandler

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/oppgave/oppdater/hendelse/TilbakekrevingMapping.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/oppdater/hendelse/TilbakekrevingMapping.kt
@@ -20,18 +20,36 @@ fun TilbakekrevingsbehandlingOppdatertHendelse.tilOppgaveOppdatering(): OppgaveO
         vurderingsbehov = emptyList(),
         mottattDokumenter = emptyList(),
         årsakTilOpprettelse = null,
-        venteInformasjon = this.gjenopptas?.let { frist ->
-            VenteInformasjon(
-                frist = frist,
-                årsakTilSattPåVent = this.venteGrunn?.name,
-                sattPåVentAv = TILBAKEKREVING,
-                begrunnelse = null,
-            )
-        },
+        venteInformasjon = if (this.behandlingStatus.erSaksbehandlerSteg()) {
+            this.gjenopptas?.let { frist ->
+                VenteInformasjon(
+                    frist = frist,
+                    årsakTilSattPåVent = this.venteGrunn?.name,
+                    sattPåVentAv = TILBAKEKREVING,
+                    begrunnelse = null,
+                )
+            }
+        } else null,
         totaltFeilutbetaltBeløp = this.totaltFeilutbetaltBeløp,
         tilbakekrevingsUrl = this.saksbehandlingURL
     )
 }
+
+/* Ventestatus fra tilbake-løsningen gjelder kun saksbehandler-steget. Påvent skal ikke
+ * henge igjen på en nyopprettet beslutter-oppgave når behandlingen sendes til godkjenning.
+ *
+ * Statusene som resulterer i avklaringsbehov SAKSBEHANDLE_TILBAKEKREVING, se tilAvklaringsBehov(). */
+fun TilbakekrevingBehandlingsstatus.erSaksbehandlerSteg(): Boolean =
+    when (this) {
+        TilbakekrevingBehandlingsstatus.OPPRETTET,
+        TilbakekrevingBehandlingsstatus.TIL_BEHANDLING,
+        TilbakekrevingBehandlingsstatus.TIL_FORHÅNDSVARSEL,
+        TilbakekrevingBehandlingsstatus.RETUR_FRA_BESLUTTER -> true
+
+        TilbakekrevingBehandlingsstatus.TIL_BESLUTTER,
+        TilbakekrevingBehandlingsstatus.TIL_GODKJENNING,
+        TilbakekrevingBehandlingsstatus.AVSLUTTET -> false
+    }
 
 fun TilbakekrevingBehandlingsstatus.tilAvklaringsBehov(): List<AvklaringsbehovHendelse> {
     return when (this) {

--- a/app/src/test/kotlin/no/nav/aap/oppgave/oppdater/hendelse/TilbakekrevingMappingTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/oppgave/oppdater/hendelse/TilbakekrevingMappingTest.kt
@@ -57,6 +57,55 @@ class TilbakekrevingMappingTest {
         assertThat(oppdatering.venteInformasjon!!.årsakTilSattPåVent).isNull()
     }
 
+    @Test
+    fun `venteInformasjon er null for TIL_GODKJENNING selv om gjenopptas og venteGrunn er satt`() {
+        val hendelseTilGodkjenning = stubTilbakekrevingsHendelse().copy(
+            behandlingStatus = TilbakekrevingBehandlingsstatus.TIL_GODKJENNING,
+            gjenopptas = LocalDate.now().plusMonths(1),
+            venteGrunn = TilbakekrevingVenteGrunn.AVVENTER_BRUKERUTTALELSE,
+        )
+
+        val oppdatering = hendelseTilGodkjenning.tilOppgaveOppdatering()
+
+        assertThat(oppdatering.venteInformasjon).isNull()
+    }
+
+    @Test
+    fun `venteInformasjon er null for TIL_BESLUTTER selv om gjenopptas og venteGrunn er satt`() {
+        val hendelseTilBeslutter = stubTilbakekrevingsHendelse().copy(
+            behandlingStatus = TilbakekrevingBehandlingsstatus.TIL_BESLUTTER,
+            gjenopptas = LocalDate.now().plusMonths(1),
+            venteGrunn = TilbakekrevingVenteGrunn.AVVENTER_BRUKERUTTALELSE,
+        )
+
+        val oppdatering = hendelseTilBeslutter.tilOppgaveOppdatering()
+
+        assertThat(oppdatering.venteInformasjon).isNull()
+    }
+
+    @Test
+    fun `venteInformasjon populeres fortsatt for saksbehandler-steg når gjenopptas er satt`() {
+        val gjenopptas = LocalDate.now().plusMonths(1)
+        val statuserForSaksbehandlerSteg = listOf(
+            TilbakekrevingBehandlingsstatus.OPPRETTET,
+            TilbakekrevingBehandlingsstatus.TIL_FORHÅNDSVARSEL,
+            TilbakekrevingBehandlingsstatus.RETUR_FRA_BESLUTTER,
+        )
+
+        statuserForSaksbehandlerSteg.forEach { status ->
+            val hendelse = stubTilbakekrevingsHendelse().copy(
+                behandlingStatus = status,
+                gjenopptas = gjenopptas,
+                venteGrunn = TilbakekrevingVenteGrunn.AVVENTER_BRUKERUTTALELSE,
+            )
+
+            val oppdatering = hendelse.tilOppgaveOppdatering()
+
+            assertThat(oppdatering.venteInformasjon).isNotNull()
+            assertThat(oppdatering.venteInformasjon!!.frist).isEqualTo(gjenopptas)
+        }
+    }
+
     private fun stubTilbakekrevingsHendelse() = TilbakekrevingsbehandlingOppdatertHendelse(
         personIdent = "12345678901",
         saksnummer = Saksnummer("SAK".plus(Random.nextLong())),


### PR DESCRIPTION
Test avdekket at tilbakekrevingsoppgaver ikke dukket opp i oppgavelista hos beslutter når følgende feature toggles var skrudd på i dev-gcp:
 - VentStatusForTilbakekrevingIBehandlingsflyt
 - VentStatusForTilbakekreving

Årsak: AVSLUTTET og TIL_GODKJENNING hendelsene fra tilbake-løsningen nullstiller ikke følgende felt:
  - vente_grunn
  - gjenopptas
 
hvis disse har vært satt i tidligere behandlings-statuser.

Problemet er at i Kelvin-oppgavelista vil påvent hindre vising i LedigOppgaver for beslutter og påvent gir heller ikke
 mening når behandlingen har kommet til beslutter.

Løsning: Bevarer feltene slik de kommer inn fra tilbake-løsningen i behandlingsflyt-tabellene:
  - tilbakekrevingshendelse
  - tilbakekrevingsbehandling

Men map kun feltene til VenteInformasjon for tilbakekrevingsoppgaver med riktig avklaringsbehov:
   -  9082/SAKSBEHANDLE_TILBAKEKREVING -> Populer VenteInformasjon (påvent status er aktuelt)
   -  9083/BESLUTTER_VEDTAK_TILBAKEKREVING -> VenteInformasjon = null 