### PR TITLE
AAP-2194 nytt endepunkt for å fjerne helseopplysning-tag på behandling

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/oppgave/mottattdokument/MottattDokumentAPI.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/mottattdokument/MottattDokumentAPI.kt
@@ -13,8 +13,7 @@ import no.nav.aap.oppgave.metrikker.httpCallCounter
 import no.nav.aap.oppgave.server.authenticate.ident
 import javax.sql.DataSource
 
-fun NormalOpenAPIRoute.mottattDokumentApi(dataSource: DataSource, prometheus: PrometheusMeterRegistry) =
-
+fun NormalOpenAPIRoute.mottattDokumentApi(dataSource: DataSource, prometheus: PrometheusMeterRegistry) {
     route("/mottatt-dokumenter-lest").post<Unit, Unit, DokumenterLestDto> { _, dto ->
         prometheus.httpCallCounter("/mottatt-dokumenter-lest").increment()
 
@@ -32,3 +31,21 @@ fun NormalOpenAPIRoute.mottattDokumentApi(dataSource: DataSource, prometheus: Pr
 
         respondWithStatus(HttpStatusCode.OK)
     }
+
+    route("/fjern-helseopplysning-ikon").post<Unit, Unit, DokumenterLestDto> { _, dto ->
+        prometheus.httpCallCounter("/fjern-helseopplysning-ikon").increment()
+
+        dataSource.transaction { connection ->
+            val mottattDokumentService = MottattDokumentService(
+                MottattDokumentRepository(connection),
+                OppgaveRepository(connection),
+            )
+
+            mottattDokumentService.registrerDokumenterLestPåBehandling(
+                behandlingRef = dto.behandlingRef,
+                ident = ident()
+            )
+        }
+        respondWithStatus(HttpStatusCode.OK)
+    }
+}

--- a/app/src/main/kotlin/no/nav/aap/oppgave/mottattdokument/MottattDokumentService.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/mottattdokument/MottattDokumentService.kt
@@ -5,21 +5,30 @@ import no.nav.aap.oppgave.verdityper.Status
 import org.slf4j.LoggerFactory
 import java.util.*
 
-private val log = LoggerFactory.getLogger(OppgaveRepository::class.java)
+private val log = LoggerFactory.getLogger(MottattDokumentService::class.java)
 
 class MottattDokumentService(
-    val mottattDokumentRepository: MottattDokumentRepository,
-    val oppgaveRepository: OppgaveRepository,
+    private val mottattDokumentRepository: MottattDokumentRepository,
+    private val oppgaveRepository: OppgaveRepository,
 ) {
     fun registrerDokumenterLest(behandlingRef: UUID, ident: String) {
+        registrerDokumenterLestPåBehandling(behandlingRef, ident)
+        registrerDokumenterLestPåOppgave(behandlingRef)
+    }
+
+    fun registrerDokumenterLestPåBehandling(behandlingRef: UUID, ident: String) {
         log.info("Registrerer dokumenter for $behandlingRef som lest")
         val ulesteDokumenter = mottattDokumentRepository.hentUlesteDokumenter(behandlingRef)
 
         if (ulesteDokumenter.isEmpty()) {
-            log.warn("Fant ingen dokumenter som ikke er registrert som lest for behanding $behandlingRef")
+            log.info("Fant ingen dokumenter som ikke er registrert som lest for behandling $behandlingRef")
             return
         }
+        mottattDokumentRepository.registrerDokumenterSomLest(behandlingRef, ident)
+        log.info("Registrerte ${ulesteDokumenter.size} dokument(er) av type ${ulesteDokumenter.joinToString(", ") { it.type }} som lest")
+    }
 
+    private fun registrerDokumenterLestPåOppgave(behandlingRef: UUID) {
         val oppgave = oppgaveRepository.hentOppgaver(behandlingRef).firstOrNull { it.status != Status.AVSLUTTET }
         require(oppgave != null) { "Fant ingen åpen oppgave for behandling $behandlingRef" }
 
@@ -27,8 +36,5 @@ class MottattDokumentService(
             oppgaveId = oppgave.oppgaveId(),
             harUlesteDokumenter = false
         )
-
-        mottattDokumentRepository.registrerDokumenterSomLest(behandlingRef, ident)
-        log.info("Registrerte ${ulesteDokumenter.size} dokument(er) av type ${ulesteDokumenter.joinToString(", ") { it.type }} som lest")
     }
 }

--- a/app/src/test/kotlin/no/nav/aap/oppgave/mottattdokument/MottattDokumentServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/oppgave/mottattdokument/MottattDokumentServiceTest.kt
@@ -7,14 +7,11 @@ import no.nav.aap.oppgave.OppgaveDto
 import no.nav.aap.oppgave.OppgaveRepository
 import no.nav.aap.oppgave.verdityper.Behandlingstype
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
 import java.util.*
-import kotlin.test.AfterTest
 
 class MottattDokumentServiceTest {
 


### PR DESCRIPTION
Splitter i to endepunkter: ett for når saksbehandler trykker dokumenter lest (skal oppdatere både behandling og oppgave) og ett for når behandling går videre til NAY og markering skal fjernes automatisk (skal bare oppdatere behandling, oppgaven lukkes samtidig).