### PR TITLE
AAP-2194 må ta hensyn til at hendelse_type kan være null

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/oppgave/OppgaveRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/OppgaveRepository.kt
@@ -425,7 +425,7 @@ class OppgaveRepository(private val connection: DBConnection) {
         }
 
         if (utvidetFilter.markertHaster == true) {
-            sb.append(" AND EXISTS (SELECT 1 FROM MARKERING m WHERE m.behandling_ref = OPPGAVE.behandling_ref AND m.MARKERING_TYPE = '${MarkeringForBehandling.HASTER}')")
+            sb.append(" AND ${behandlingHarAktivMarkeringClause("('${MarkeringForBehandling.HASTER}')")}")
         }
 
         return sb.toString()
@@ -455,8 +455,7 @@ class OppgaveRepository(private val connection: DBConnection) {
         )
         val sorteringsRekkefølge = oppgaveRekkefølge(rekkefølge)
         val orderBy = if (hastemarkeringerFørst) {
-            "ORDER BY CASE WHEN EXISTS (SELECT 1 FROM MARKERING m WHERE m.behandling_ref = OPPGAVE.behandling_ref " +
-                    "AND m.markering_type='${MarkeringForBehandling.HASTER}') THEN 0 ELSE 1 END, $sortering $sorteringsRekkefølge"
+            "ORDER BY CASE WHEN ${behandlingHarAktivMarkeringClause("('${MarkeringForBehandling.HASTER}')")} THEN 0 ELSE 1 END, $sortering $sorteringsRekkefølge"
         } else {
             "ORDER BY $sortering $sorteringsRekkefølge"
         }
@@ -766,18 +765,14 @@ class OppgaveRepository(private val connection: DBConnection) {
         if (inkluderteMarkeringer.isNotEmpty()) {
             val stringListeAvMarkeringer =
                 inkluderteMarkeringer.joinToString(prefix = "(", postfix = ")", separator = ", ") { "'${it.name}'" }
-            sb.append(
-                "EXISTS (SELECT 1 FROM MARKERING m WHERE m.behandling_ref = OPPGAVE.behandling_ref AND m.MARKERING_TYPE IN $stringListeAvMarkeringer) AND "
-            )
+            sb.append("${behandlingHarAktivMarkeringClause(stringListeAvMarkeringer)} AND ")
         }
 
         // Markeringer - ekskluder
         if (ekskluderteMarkeringer.isNotEmpty()) {
             val stringListeAvMarkeringer =
                 ekskluderteMarkeringer.joinToString(prefix = "(", postfix = ")", separator = ", ") { "'${it.name}'" }
-            sb.append(
-                "NOT EXISTS (SELECT 1 FROM MARKERING m WHERE m.behandling_ref = OPPGAVE.behandling_ref AND m.MARKERING_TYPE IN $stringListeAvMarkeringer) AND "
-            )
+            sb.append("NOT ${behandlingHarAktivMarkeringClause(stringListeAvMarkeringer)} AND ")
         }
 
         // Enheter
@@ -931,6 +926,22 @@ class OppgaveRepository(private val connection: DBConnection) {
             OppgaveSorteringRekkefølge.DESC -> Rekkefølge.desc
         }
     }
+
+    private fun behandlingHarAktivMarkeringClause(markeringTyperSql: String): String {
+        return """
+        EXISTS (
+            SELECT 1 FROM (
+                SELECT DISTINCT ON (markering_type) hendelse_type
+                FROM MARKERING
+                WHERE behandling_ref = OPPGAVE.behandling_ref
+                  AND markering_type IN $markeringTyperSql
+                ORDER BY markering_type, opprettet_tid DESC
+            ) gjeldende
+            WHERE gjeldende.hendelse_type = 'OPPRETTET'
+        )
+    """.trimIndent()
+    }
+
 
     private companion object {
         val alleOppgaveFelt = """

--- a/app/src/main/kotlin/no/nav/aap/oppgave/OppgaveRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/OppgaveRepository.kt
@@ -928,6 +928,7 @@ class OppgaveRepository(private val connection: DBConnection) {
     }
 
     private fun behandlingHarAktivMarkeringClause(markeringTyperSql: String): String {
+        // nyeste markering-hendelse på behandling må ha hendelse-type lik null eller OPPRETTET
         return """
         EXISTS (
             SELECT 1 FROM (
@@ -937,7 +938,7 @@ class OppgaveRepository(private val connection: DBConnection) {
                   AND markering_type IN $markeringTyperSql
                 ORDER BY markering_type, opprettet_tid DESC
             ) gjeldende
-            WHERE gjeldende.hendelse_type = 'OPPRETTET'
+            WHERE gjeldende.hendelse_type IS DISTINCT FROM 'FJERNET'
         )
     """.trimIndent()
     }

--- a/app/src/test/kotlin/no/nav/aap/oppgave/OppgaveRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/oppgave/OppgaveRepositoryTest.kt
@@ -1130,6 +1130,43 @@ class OppgaveRepositoryTest {
     }
 
     @Test
+    fun `Når hastemarkering fjernes skal oppgave ikke ligge først etter sortering lenger`() {
+        val hasteBehandlingref1 = UUID.randomUUID()
+        markerHasteOppgave(hasteBehandlingref1)
+        val hasteOppgave = opprettOppgave(
+            behandlingRef = hasteBehandlingref1,
+            enhet = ENHET_NAV_ENEBAKK,
+            behandlingOpprettet = LocalDateTime.now().minusDays(10)
+        )
+
+        val vanligOppgave =
+            opprettOppgave(enhet = ENHET_NAV_ENEBAKK, behandlingOpprettet = LocalDateTime.now().minusDays(4))
+
+        val søkPåBehandlingOpprettetNyesteFørst =
+            finnLedigeOppgaver(
+                TransientFilterDto(enheter = setOf(ENHET_NAV_ENEBAKK)),
+                sortBy = OppgaveSorteringFelt.BEHANDLING_OPPRETTET,
+                rekkefølge = OppgaveSorteringRekkefølge.DESC
+            )
+
+        assertThat(søkPåBehandlingOpprettetNyesteFørst.oppgaver.first().oppgaveId()).isEqualTo(hasteOppgave)
+        assertThat(søkPåBehandlingOpprettetNyesteFørst.oppgaver.last().oppgaveId()).isEqualTo(vanligOppgave)
+
+        // fjerner hastemarkering
+        fjernHastemarkering(hasteBehandlingref1)
+
+        val søkPåBehandlingOpprettetNyesteFørst2 =
+            finnLedigeOppgaver(
+                TransientFilterDto(enheter = setOf(ENHET_NAV_ENEBAKK)),
+                sortBy = OppgaveSorteringFelt.BEHANDLING_OPPRETTET,
+                rekkefølge = OppgaveSorteringRekkefølge.DESC
+            )
+
+        assertThat(søkPåBehandlingOpprettetNyesteFørst2.oppgaver.first().oppgaveId()).isEqualTo(vanligOppgave)
+        assertThat(søkPåBehandlingOpprettetNyesteFørst2.oppgaver.last().oppgaveId()).isEqualTo(hasteOppgave)
+    }
+
+    @Test
     fun `Skal filtrere oppgaver basert på én markeringstype`() {
         val hasteRef = UUID.randomUUID()
         val avslag115Ref = UUID.randomUUID()
@@ -1346,6 +1383,16 @@ class OppgaveRepositoryTest {
             markeringRepository.lagreMarkeringHendelse(
                 hasterBehandlingsref,
                 BehandlingMarkering(MarkeringForBehandling.HASTER, "haster", opprettetAv = "me", opprettetTidspunkt = LocalDateTime.now(), hendelseType = MarkeringHendelseType.OPPRETTET)
+            )
+        }
+    }
+
+    private fun fjernHastemarkering(hasterBehandlingsref: UUID) {
+        dataSource.transaction { connection ->
+            val markeringRepository = MarkeringRepository(connection)
+            markeringRepository.lagreMarkeringHendelse(
+                hasterBehandlingsref,
+                BehandlingMarkering(MarkeringForBehandling.HASTER, "haster", opprettetAv = "me", opprettetTidspunkt = LocalDateTime.now(), hendelseType = MarkeringHendelseType.FJERNET)
             )
         }
     }


### PR DESCRIPTION
Forrige fiks funket ikke fordi den antok at hendelse_type-feltet hadde OPPRETTET som default, så da forsvant alle hastemarkeringer opprettet før den endringen kom. Må isteden sjekke at hendelse_type ikke er lik FJERNET.