### PR TITLE
AAP-2235 Splitt oppgave i domene-objekt og dto

### DIFF
--- a/api-kontrakt/src/main/kotlin/no/nav/aap/oppgave/OppgaveDto.kt
+++ b/api-kontrakt/src/main/kotlin/no/nav/aap/oppgave/OppgaveDto.kt
@@ -47,8 +47,8 @@ enum class ÅrsakTilReturKode {
 }
 
 data class OppgaveDto(
-    val id: Long? = null,
-    val personIdent: String? = null,
+    val id: Long,
+    val personIdent: String,
     val personNavn: String? = null,
     val saksnummer: String? = null,
     val behandlingRef: UUID,

--- a/api-kontrakt/src/main/kotlin/no/nav/aap/oppgave/OppgaveDto.kt
+++ b/api-kontrakt/src/main/kotlin/no/nav/aap/oppgave/OppgaveDto.kt
@@ -91,7 +91,7 @@ data class OppgaveDto(
     val forrigeKvalitetssikrerInfo: ForrigeKvalitetssikrerInfo? = null,
 ) {
     fun oppgaveId() = OppgaveId(
-        requireNotNull(id) { "Oppgave har ingen id" },
+        id,
         versjon,
     )
 }

--- a/api-kontrakt/src/main/kotlin/no/nav/aap/oppgave/OppgaveDto.kt
+++ b/api-kontrakt/src/main/kotlin/no/nav/aap/oppgave/OppgaveDto.kt
@@ -46,10 +46,6 @@ enum class ÅrsakTilReturKode {
     MANGLENDE_KILDEHENVISNING,
 }
 
-/**
- * @param enhet Enhetsnummeret til enheten som er koblet til oppgaven.
- * TODO: Fjern sensitive felter
- */
 data class OppgaveDto(
     val id: Long? = null,
     val personIdent: String? = null,
@@ -94,34 +90,6 @@ data class OppgaveDto(
     val tilbakekrevingsVarsDto: TilbakekrevingsVarsDto? = null,
     val forrigeKvalitetssikrerInfo: ForrigeKvalitetssikrerInfo? = null,
 ) {
-    /**
-     * Oppfølgingsenhet skal alltid prioriteres dersom den er satt.
-     * Brukes for å sikre at oppgaver havner i riktig kø i oppgavelisten.
-     **/
-    val enhetForKø: String = oppfølgingsenhet ?: enhet
-
-    val erPåVent: Boolean = påVentTil != null
-
-    val erÅpen: Boolean = status == Status.OPPRETTET
-
-    init {
-        if (journalpostId == null) {
-            if (saksnummer == null) {
-                throw IllegalArgumentException("Saksnummer og behandlingRef kan ikke være null dersom journalpostId er null")
-            }
-        }
-    }
-
-    fun tilAvklaringsbehovReferanseDto(): AvklaringsbehovReferanseDto {
-        return AvklaringsbehovReferanseDto(
-            referanse = this.behandlingRef,
-            saksnummer = this.saksnummer,
-            journalpostId = this.journalpostId,
-            avklaringsbehovKode = this.avklaringsbehovKode,
-            behandlingstype = this.behandlingstype
-        )
-    }
-
     fun oppgaveId() = OppgaveId(
         requireNotNull(id) { "Oppgave har ingen id" },
         versjon,

--- a/app/src/main/kotlin/no/nav/aap/oppgave/Oppgave.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/Oppgave.kt
@@ -136,7 +136,9 @@ data class Oppgave(
             harFortroligAdresse = harFortroligAdresse,
             harUlesteDokumenter = harUlesteDokumenter,
             vurderingsbehov = vurderingsbehov,
-            personIdent = personIdent,
+            personIdent = requireNotNull(personIdent) {
+                "Personident kan ikke være null for OppgaveDto"
+            },
             personNavn = personNavn,
             behandlingRef = behandlingRef,
             enhet = enhet,

--- a/app/src/main/kotlin/no/nav/aap/oppgave/Oppgave.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/Oppgave.kt
@@ -101,7 +101,7 @@ data class Oppgave(
     init {
         if (journalpostId == null) {
             if (saksnummer == null) {
-                throw IllegalArgumentException("Saksnummer og behandlingRef kan ikke være null dersom journalpostId er null")
+                throw IllegalArgumentException("Saksnummer kan ikke være null dersom journalpostId er null")
             }
         }
     }

--- a/app/src/main/kotlin/no/nav/aap/oppgave/Oppgave.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/Oppgave.kt
@@ -1,0 +1,168 @@
+package no.nav.aap.oppgave
+
+import no.nav.aap.oppgave.enhet.EnhetDto
+import no.nav.aap.oppgave.markering.MarkeringDto
+import no.nav.aap.oppgave.verdityper.Behandlingstype
+import no.nav.aap.oppgave.verdityper.Status
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+data class ReturInfo(
+    val status: ReturStatus,
+    val årsaker: List<ÅrsakTilReturKode>,
+    val begrunnelse: String,
+    val endretAv: String,
+) {
+    fun tilDto(): ReturInformasjon = ReturInformasjon(
+        status = status,
+        årsaker = årsaker,
+        begrunnelse = begrunnelse,
+        endretAv = endretAv
+    )
+}
+
+@Suppress("PropertyName")
+data class TilbakekrevingsVars(
+    val tilbakekrevings_URL : String,
+    val tilbakekrevings_beløp: BigDecimal
+) {
+    fun tilDto(): TilbakekrevingsVarsDto = TilbakekrevingsVarsDto(
+        tilbakekrevings_URL = tilbakekrevings_URL,
+        tilbakekrevings_beløp = tilbakekrevings_beløp
+    )
+}
+
+data class ForrigeKvalitetssikrer(
+    val forrigeKvalitetssikrerIdent: String,
+    val forrigeKvalitetssikrerNavn: String? = null,
+) {
+    fun tilDto(): ForrigeKvalitetssikrerInfo = ForrigeKvalitetssikrerInfo(
+        forrigeKvalitetssikrerIdent = forrigeKvalitetssikrerIdent,
+        forrigeKvalitetssikrerNavn = forrigeKvalitetssikrerNavn
+    )
+}
+
+data class Oppgave(
+    val id: Long? = null,
+    val personIdent: String? = null,
+    val personNavn: String? = null,
+    val saksnummer: String? = null,
+    val behandlingRef: UUID,
+    val journalpostId: Long? = null,
+    val enhet: String,
+    val enhetForrigeOppgave: EnhetDto? = null,
+    val oppfølgingsenhet: String?,
+    val veilederArbeid: String? = null,
+    val veilederSykdom: String? = null,
+    val behandlingOpprettet: LocalDateTime,
+    val avklaringsbehovKode: String,
+    val status: Status = Status.OPPRETTET,
+    val behandlingstype: Behandlingstype,
+    val påVentTil: LocalDate? = null,
+    val påVentÅrsak: String? = null,
+    val utløptVentefrist: LocalDate? = null,
+    val venteBegrunnelse: String? = null,
+    val forrigePåVentÅrsak: String? = null,
+    val forrigeVenteBegrunnelse: String? = null,
+    @Deprecated("Bruk returInformasjon")
+    val returStatus: ReturStatus? = null,
+    val returInformasjon: ReturInfo? = null,
+    @Deprecated("Bytt til vurderingsbehov når frontend er oppdatert")
+    val årsakerTilBehandling: List<String> = emptyList(),
+    val vurderingsbehov: List<String> = emptyList(),
+    val årsakTilOpprettelse: String? = null,
+    val reservertAv: String? = null,
+    val reservertAvNavn: String? = null,
+    val reservertTidspunkt: LocalDateTime? = null,
+    val opprettetAv: String,
+    val opprettetTidspunkt: LocalDateTime,
+    val endretAv: String? = null,
+    val endretTidspunkt: LocalDateTime? = null,
+    val versjon: Long = 0,
+    val harFortroligAdresse: Boolean? = false,
+    val erSkjermet: Boolean? = false,
+    val harUlesteDokumenter: Boolean? = false,
+    val markeringer: List<MarkeringDto> = emptyList(),
+    val tilbakekrevingsVars: TilbakekrevingsVars? = null,
+    val forrigeKvalitetssikrerInfo: ForrigeKvalitetssikrer? = null,
+) {
+    /**
+     * Oppfølgingsenhet skal alltid prioriteres dersom den er satt.
+     * Brukes for å sikre at oppgaver havner i riktig kø i oppgavelisten.
+     **/
+    val enhetForKø: String = oppfølgingsenhet ?: enhet
+
+    val erPåVent: Boolean = påVentTil != null
+
+    val erÅpen: Boolean = status == Status.OPPRETTET
+
+    init {
+        if (journalpostId == null) {
+            if (saksnummer == null) {
+                throw IllegalArgumentException("Saksnummer og behandlingRef kan ikke være null dersom journalpostId er null")
+            }
+        }
+    }
+
+    fun oppgaveId() = OppgaveId(
+        requireNotNull(id) { "Oppgave har ingen id" },
+        versjon,
+    )
+
+    fun tilAvklaringsbehovReferanseDto(): AvklaringsbehovReferanseDto {
+        return AvklaringsbehovReferanseDto(
+            referanse = this.behandlingRef,
+            saksnummer = this.saksnummer,
+            journalpostId = this.journalpostId,
+            avklaringsbehovKode = this.avklaringsbehovKode,
+            behandlingstype = this.behandlingstype
+        )
+    }
+
+    fun tilOppgaveDto(): OppgaveDto {
+        return OppgaveDto(
+            id = requireNotNull(id) { "Oppgave må ha ID" },
+            saksnummer = saksnummer,
+            journalpostId = journalpostId,
+            avklaringsbehovKode = avklaringsbehovKode,
+            behandlingOpprettet = behandlingOpprettet,
+            behandlingstype = behandlingstype,
+            status = status,
+            endretAv = endretAv,
+            endretTidspunkt = endretTidspunkt,
+            versjon = versjon,
+            harFortroligAdresse = harFortroligAdresse,
+            harUlesteDokumenter = harUlesteDokumenter,
+            vurderingsbehov = vurderingsbehov,
+            personIdent = personIdent,
+            personNavn = personNavn,
+            behandlingRef = behandlingRef,
+            enhet = enhet,
+            enhetForrigeOppgave = enhetForrigeOppgave,
+            oppfølgingsenhet = oppfølgingsenhet,
+            veilederArbeid = veilederArbeid,
+            veilederSykdom = veilederSykdom,
+            påVentTil = påVentTil,
+            påVentÅrsak = påVentÅrsak,
+            utløptVentefrist = utløptVentefrist,
+            venteBegrunnelse = venteBegrunnelse,
+            forrigePåVentÅrsak = forrigePåVentÅrsak,
+            forrigeVenteBegrunnelse = forrigeVenteBegrunnelse,
+            returStatus = returStatus,
+            returInformasjon = returInformasjon?.tilDto(),
+            årsakerTilBehandling = årsakerTilBehandling,
+            årsakTilOpprettelse = årsakTilOpprettelse,
+            reservertAv = reservertAv,
+            reservertAvNavn = reservertAvNavn,
+            reservertTidspunkt = reservertTidspunkt,
+            opprettetAv = opprettetAv,
+            opprettetTidspunkt = opprettetTidspunkt,
+            erSkjermet = erSkjermet,
+            markeringer = markeringer,
+            tilbakekrevingsVarsDto = tilbakekrevingsVars?.tilDto(),
+            forrigeKvalitetssikrerInfo = forrigeKvalitetssikrerInfo?.tilDto(),
+        )
+    }
+}

--- a/app/src/main/kotlin/no/nav/aap/oppgave/OppgaveRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/OppgaveRepository.kt
@@ -27,7 +27,7 @@ class FeilVersjonException(
 
 class OppgaveRepository(private val connection: DBConnection) {
 
-    fun opprettOppgave(oppgaveDto: OppgaveDto): OppgaveId {
+    fun opprettOppgave(oppgave: Oppgave): OppgaveId {
         val query = """
             INSERT INTO OPPGAVE (
                 SAKSNUMMER,
@@ -65,40 +65,40 @@ class OppgaveRepository(private val connection: DBConnection) {
         """.trimIndent()
         val id = connection.executeReturnKey(query) {
             setParams {
-                setString(1, oppgaveDto.saksnummer)
-                setUUID(2, oppgaveDto.behandlingRef)
-                setLong(3, oppgaveDto.journalpostId)
-                setString(4, oppgaveDto.enhet)
-                setString(5, oppgaveDto.oppfølgingsenhet)
-                setLocalDateTime(6, oppgaveDto.behandlingOpprettet)
-                setString(7, oppgaveDto.avklaringsbehovKode)
-                setString(8, oppgaveDto.status.name)
-                setString(9, oppgaveDto.behandlingstype.name)
-                setLocalDate(10, oppgaveDto.påVentTil)
-                setString(11, oppgaveDto.påVentÅrsak)
-                setString(12, oppgaveDto.opprettetAv)
-                setLocalDateTime(13, oppgaveDto.opprettetTidspunkt)
-                setString(14, oppgaveDto.personIdent)
-                setString(15, oppgaveDto.veilederArbeid)
-                setString(16, oppgaveDto.veilederSykdom)
-                setArray(17, oppgaveDto.vurderingsbehov)
-                setString(18, oppgaveDto.venteBegrunnelse)
-                setString(19, oppgaveDto.påVentÅrsak)
-                setString(20, oppgaveDto.venteBegrunnelse)
-                setBoolean(21, oppgaveDto.harFortroligAdresse)
-                setBoolean(22, oppgaveDto.harUlesteDokumenter)
-                setEnumName(23, oppgaveDto.returInformasjon?.status)
-                setString(24, oppgaveDto.returInformasjon?.begrunnelse)
-                setArray(25, oppgaveDto.returInformasjon?.årsaker?.map { it.name } ?: emptyList())
-                setString(26, oppgaveDto.returInformasjon?.endretAv)
-                setString(27, oppgaveDto.årsakTilOpprettelse)
-                setBoolean(28, oppgaveDto.erSkjermet)
+                setString(1, oppgave.saksnummer)
+                setUUID(2, oppgave.behandlingRef)
+                setLong(3, oppgave.journalpostId)
+                setString(4, oppgave.enhet)
+                setString(5, oppgave.oppfølgingsenhet)
+                setLocalDateTime(6, oppgave.behandlingOpprettet)
+                setString(7, oppgave.avklaringsbehovKode)
+                setString(8, oppgave.status.name)
+                setString(9, oppgave.behandlingstype.name)
+                setLocalDate(10, oppgave.påVentTil)
+                setString(11, oppgave.påVentÅrsak)
+                setString(12, oppgave.opprettetAv)
+                setLocalDateTime(13, oppgave.opprettetTidspunkt)
+                setString(14, oppgave.personIdent)
+                setString(15, oppgave.veilederArbeid)
+                setString(16, oppgave.veilederSykdom)
+                setArray(17, oppgave.vurderingsbehov)
+                setString(18, oppgave.venteBegrunnelse)
+                setString(19, oppgave.påVentÅrsak)
+                setString(20, oppgave.venteBegrunnelse)
+                setBoolean(21, oppgave.harFortroligAdresse)
+                setBoolean(22, oppgave.harUlesteDokumenter)
+                setEnumName(23, oppgave.returInformasjon?.status)
+                setString(24, oppgave.returInformasjon?.begrunnelse)
+                setArray(25, oppgave.returInformasjon?.årsaker?.map { it.name } ?: emptyList())
+                setString(26, oppgave.returInformasjon?.endretAv)
+                setString(27, oppgave.årsakTilOpprettelse)
+                setBoolean(28, oppgave.erSkjermet)
             }
         }
         return OppgaveId(id, 0L)
     }
 
-    fun hentAktivOppgave(behandlingReferanse: BehandlingReferanse): OppgaveDto? {
+    fun hentAktivOppgave(behandlingReferanse: BehandlingReferanse): Oppgave? {
         val oppgaverForIdQuery = """
             SELECT 
                 $alleOppgaveFelt
@@ -121,7 +121,7 @@ class OppgaveRepository(private val connection: DBConnection) {
         }
     }
 
-    fun hentOppgaverForIdent(ident: String): List<OppgaveDto> {
+    fun hentOppgaverForIdent(ident: String): List<Oppgave> {
         val oppgaverForIdQuery = """
             SELECT 
                 $alleOppgaveFelt
@@ -143,7 +143,7 @@ class OppgaveRepository(private val connection: DBConnection) {
         }
     }
 
-    fun hentOppgave(oppgaveId: Long): OppgaveDto {
+    fun hentOppgave(oppgaveId: Long): Oppgave {
         val oppgaverForIdQuery = """
             SELECT 
                 $alleOppgaveFelt
@@ -164,7 +164,7 @@ class OppgaveRepository(private val connection: DBConnection) {
         }
     }
 
-    fun hentOppgaver(referanse: UUID): List<OppgaveDto> {
+    fun hentOppgaver(referanse: UUID): List<Oppgave> {
         val oppgaverForReferanseQuery = """
         SELECT 
             $alleOppgaveFelt
@@ -200,7 +200,7 @@ class OppgaveRepository(private val connection: DBConnection) {
         harFortroligAdresse: Boolean? = false,
         erSkjermet: Boolean,
         harUlesteDokumenter: Boolean? = false,
-        returInformasjon: ReturInformasjon?,
+        returInformasjon: ReturInfo?,
         utløptVentefrist: LocalDate? = null,
         forrigeKvalitetssikrerIdent: String? = null,
         forrigeKvalitetssikrerNavn: String? = null,
@@ -505,7 +505,7 @@ class OppgaveRepository(private val connection: DBConnection) {
 
 
     data class IdentMedOppgaveId(val ident: String, val oppgaveId: Long, val versjon: Long)
-    data class FinnOppgaverDto(val oppgaver: List<OppgaveDto>, val antallGjenstaaende: Int, val antallTotalt: Int)
+    data class FinnOppgaverDto(val oppgaver: List<Oppgave>, val antallGjenstaaende: Int, val antallTotalt: Int)
 
     fun finnÅpneOppgaverIkkeVikafossen(): List<IdentMedOppgaveId> {
         val query = """
@@ -553,7 +553,7 @@ class OppgaveRepository(private val connection: DBConnection) {
         }
     }
 
-    fun finnOppgaverGittSaksnummer(saksnummer: String): List<OppgaveDto> {
+    fun finnOppgaverGittSaksnummer(saksnummer: String): List<Oppgave> {
         val hentOppgaverGittSaksnummerQuery = """
             SELECT 
                    $alleOppgaveFelt
@@ -575,7 +575,7 @@ class OppgaveRepository(private val connection: DBConnection) {
         }
     }
 
-    fun finnÅpneOppgaverGittPersonident(personIdent: String): List<OppgaveDto> {
+    fun finnÅpneOppgaverGittPersonident(personIdent: String): List<Oppgave> {
         val hentOppgaverGittPersonidentQuery = """
             SELECT 
                    $alleOppgaveFelt
@@ -649,7 +649,7 @@ class OppgaveRepository(private val connection: DBConnection) {
         kunPåVent: Boolean = false,
         sortBy: OppgaveSorteringFelt? = null,
         sortOrder: OppgaveSorteringRekkefølge? = null
-    ): List<OppgaveDto> {
+    ): List<Oppgave> {
         val kunPåVentQuery = if (kunPåVent) " AND PAA_VENT_TIL IS NOT NULL" else ""
         val sortering = oppgaveSorteringQuery(
             sortBy ?: OppgaveSorteringFelt.BEHANDLING_OPPRETTET,
@@ -677,7 +677,7 @@ class OppgaveRepository(private val connection: DBConnection) {
     }
 
 
-    fun hentAlleÅpneOppgaver(): List<OppgaveDto> {
+    fun hentAlleÅpneOppgaver(): List<Oppgave> {
         val query = """
             SELECT 
                 $alleOppgaveFelt
@@ -792,15 +792,15 @@ class OppgaveRepository(private val connection: DBConnection) {
 
     private fun oppgaveMapper(
         row: Row,
-        tilbakekrevingVars: TilbakekrevingsVarsDto?,
+        tilbakekrevingVars: TilbakekrevingsVars?,
         enhetNrForrigeOppgave: String? = null,
         enheterMedNavn: Map<String, String> = emptyMap()
-    ): OppgaveDto {
+    ): Oppgave {
         val enhetForrigeOppgave = enhetNrForrigeOppgave?.let { enhetNr ->
             EnhetDto(enhetNr = enhetNr, navn = enheterMedNavn[enhetNr] ?: enhetNr)
         }
 
-        val standardOppgaveDto = OppgaveDto(
+        val standardOppgave = Oppgave(
             id = row.getLong("ID"),
             personIdent = row.getStringOrNull("PERSON_IDENT"),
             saksnummer = row.getStringOrNull("SAKSNUMMER"),
@@ -837,7 +837,7 @@ class OppgaveRepository(private val connection: DBConnection) {
             returStatus = row.getEnumOrNull<ReturStatus?, ReturStatus>("RETUR_AARSAK"),
             utløptVentefrist = row.getLocalDateOrNull("UTLOEPT_VENTEFRIST"),
             returInformasjon = row.getEnumOrNull<ReturStatus?, ReturStatus>("RETUR_AARSAK")?.let {
-                ReturInformasjon(
+                ReturInfo(
                     status = it,
                     årsaker = row.getArray("RETUR_AARSAKER", String::class)
                         .map { årsak -> ÅrsakTilReturKode.valueOf(årsak) },
@@ -845,9 +845,9 @@ class OppgaveRepository(private val connection: DBConnection) {
                     endretAv = row.getStringOrNull("retur_returnert_av") ?: "UKJENT",
                 )
             },
-            tilbakekrevingsVarsDto = tilbakekrevingVars,
+            tilbakekrevingsVars = tilbakekrevingVars,
             forrigeKvalitetssikrerInfo = row.getStringOrNull("FORRIGE_KVALITETSSIKRER_IDENT")?.let {
-                ForrigeKvalitetssikrerInfo(
+                ForrigeKvalitetssikrer(
                     forrigeKvalitetssikrerIdent = it,
                     forrigeKvalitetssikrerNavn = row.getStringOrNull("FORRIGE_KVALITETSSIKRER_NAVN")
                 )
@@ -856,8 +856,8 @@ class OppgaveRepository(private val connection: DBConnection) {
 
         val behandlingstype = Behandlingstype.valueOf(row.getString("BEHANDLINGSTYPE"))
         return when (behandlingstype) {
-            Behandlingstype.TILBAKEKREVING -> tilpassPåventDataForTilbakekreving(standardOppgaveDto, row)
-            else -> standardOppgaveDto
+            Behandlingstype.TILBAKEKREVING -> tilpassPåventDataForTilbakekreving(standardOppgave, row)
+            else -> standardOppgave
         }
 
     }
@@ -868,15 +868,15 @@ class OppgaveRepository(private val connection: DBConnection) {
         - Utløpt påvent frist blir ikke varslet fra tilbake-løsninge, vi må selv sjekke ved henting av oppgaveliste om dagens dato har passert frist(gjenopptas) dato
         - Oppheving av status påvent (påvent-status eller utløpt-status) skjer når tilbakeløsningen sender inn kafka behandling_endres uten grunn/gjenopptas-dato */
     private fun tilpassPåventDataForTilbakekreving(
-        standardOppgaveDto: OppgaveDto,
+        standardOppgave: Oppgave,
         row: Row
-    ): OppgaveDto {
+    ): Oppgave {
 
         val påVentTil = row.getLocalDateOrNull("PAA_VENT_TIL")
         val utløptVentefrist = row.getLocalDateOrNull("UTLOEPT_VENTEFRIST")
         val erFristUtløpt = påVentTil != null && påVentTil <= LocalDate.now() && utløptVentefrist == null
 
-        return standardOppgaveDto.copy(
+        return standardOppgave.copy(
             påVentTil = if (erFristUtløpt) null else påVentTil,
             påVentÅrsak = if (erFristUtløpt) null else row.getStringOrNull("PAA_VENT_AARSAK"),
             venteBegrunnelse = if (erFristUtløpt) null else row.getStringOrNull("VENTE_BEGRUNNELSE"),
@@ -891,13 +891,13 @@ class OppgaveRepository(private val connection: DBConnection) {
     private fun getTilbakekreving(
         row: Row,
         connection: DBConnection
-    ): TilbakekrevingsVarsDto? {
-        var tilbakekrevingVars: TilbakekrevingsVarsDto? = null
+    ): TilbakekrevingsVars? {
+        var tilbakekrevingVars: TilbakekrevingsVars? = null
         val behandlingstype = Behandlingstype.valueOf(row.getString("BEHANDLINGSTYPE"))
         if (behandlingstype == Behandlingstype.TILBAKEKREVING) {
             val tilbakekreving = TilbakekrevingRepository(connection).hent(row.getLong("ID"))
             tilbakekrevingVars =
-                TilbakekrevingsVarsDto(
+                TilbakekrevingsVars(
                     tilbakekreving.url,
                     tilbakekreving.beløp
                 )

--- a/app/src/main/kotlin/no/nav/aap/oppgave/drift/DriftApi.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/drift/DriftApi.kt
@@ -12,7 +12,7 @@ import no.nav.aap.behandlingsflyt.kontrakt.avklaringsbehov.Definisjon
 import no.nav.aap.behandlingsflyt.kontrakt.avklaringsbehov.Definisjon.BehovType
 import no.nav.aap.behandlingsflyt.kontrakt.behandling.BehandlingReferanse
 import no.nav.aap.komponenter.dbconnect.transaction
-import no.nav.aap.oppgave.OppgaveDto
+import no.nav.aap.oppgave.Oppgave
 import no.nav.aap.oppgave.OppgaveRepository
 import no.nav.aap.oppgave.enhet.EnhetService
 import no.nav.aap.oppgave.filter.EnhetFilter
@@ -182,7 +182,7 @@ private fun FilterDto.tilDriftResponse(enhetPerFilter: Map<Long, List<EnhetFilte
     endretTidspunkt = endretTidspunkt,
 )
 
-private fun OppgaveDto.mapTilOppgaveDriftsinfo(historikk: List<OppgaveHistorikk>) = OppgaveDriftsinfoDTO(
+private fun Oppgave.mapTilOppgaveDriftsinfo(historikk: List<OppgaveHistorikk>) = OppgaveDriftsinfoDTO(
     oppgaveId = id!!,
     behandlingRef = behandlingRef,
     status = status,

--- a/app/src/main/kotlin/no/nav/aap/oppgave/enhet/EnhetAPI.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/enhet/EnhetAPI.kt
@@ -13,7 +13,7 @@ import no.nav.aap.komponenter.server.auth.token
 import no.nav.aap.motor.FlytJobbRepository
 import no.nav.aap.oppgave.AVKLARINGSBEHOV_FOR_VEILEDER_OG_SAKSBEHANDLER
 import no.nav.aap.oppgave.AvklaringsbehovKode
-import no.nav.aap.oppgave.OppgaveDto
+import no.nav.aap.oppgave.Oppgave
 import no.nav.aap.oppgave.OppgaveRepository
 import no.nav.aap.oppgave.klienter.arena.VeilarbarenaGateway
 import no.nav.aap.oppgave.klienter.behandlingsflyt.BehandlingsflytGateway
@@ -87,9 +87,9 @@ fun NormalOpenAPIRoute.enhetStatus(dataSource: DataSource) =
  * Returnerer første oppgave i den siste sammenhengende bolken av oppgaver fra kandidatlisten
  * */
 private fun førsteISisteSammenhengendeBlokk(
-    alleOppgaver: List<OppgaveDto>,
-    kandidater: List<OppgaveDto>
-): OppgaveDto {
+    alleOppgaver: List<Oppgave>,
+    kandidater: List<Oppgave>
+): Oppgave {
     val kandidatSet = kandidater.toSet()
     return alleOppgaver
         .reversed()
@@ -98,7 +98,7 @@ private fun førsteISisteSammenhengendeBlokk(
         .lastOrNull() ?: kandidater.first()
 }
 
-internal fun enhetOgOversendelse(alleOppgaver: List<OppgaveDto>, hasteBehandlinger: List<UUID>): NåværendeEnhet? {
+internal fun enhetOgOversendelse(alleOppgaver: List<Oppgave>, hasteBehandlinger: List<UUID>): NåværendeEnhet? {
     val log = LoggerFactory.getLogger("enhet-status")
 
     val alleOppgaver = alleOppgaver
@@ -112,16 +112,16 @@ internal fun enhetOgOversendelse(alleOppgaver: List<OppgaveDto>, hasteBehandling
 
     val oppgaver = alleOppgaver.filter { it.behandlingRef == behandlingReferanse }
 
-    val erHosNAY: (oppgave: OppgaveDto) -> Boolean =
+    val erHosNAY: (oppgave: Oppgave) -> Boolean =
         { oppgave -> oppgave.enhetForKø in NAY_ENHETER.map { it.kode } }
 
     val erHastesak =
-        { oppgave: OppgaveDto -> oppgave.behandlingRef in hasteBehandlinger }
+        { oppgave: Oppgave -> oppgave.behandlingRef in hasteBehandlinger }
 
-    val erKvalitetssikring: (oppgave: OppgaveDto) -> Boolean =
+    val erKvalitetssikring: (oppgave: Oppgave) -> Boolean =
         { oppgave -> oppgave.avklaringsbehovKode == Definisjon.KVALITETSSIKRING.kode.name }
 
-    val erBeslutterOppgave: (oppgave: OppgaveDto) -> Boolean =
+    val erBeslutterOppgave: (oppgave: Oppgave) -> Boolean =
         { oppgave ->
             Definisjon.entries.filter { it.løsesAv.contains(Rolle.BESLUTTER) }
                 .any { it.kode.name == oppgave.avklaringsbehovKode }

--- a/app/src/main/kotlin/no/nav/aap/oppgave/oppdater/OppdaterOppgaveService.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/oppdater/OppdaterOppgaveService.kt
@@ -9,10 +9,10 @@ import no.nav.aap.oppgave.AVKLARINGSBEHOV_FOR_VEILEDER
 import no.nav.aap.oppgave.AVKLARINGSBEHOV_FOR_VEILEDER_OG_SAKSBEHANDLER
 import no.nav.aap.oppgave.AVKLARINGSBEHOV_FOR_VEILEDER_POSTMOTTAK
 import no.nav.aap.oppgave.AvklaringsbehovKode
-import no.nav.aap.oppgave.OppgaveDto
+import no.nav.aap.oppgave.Oppgave
 import no.nav.aap.oppgave.OppgaveId
 import no.nav.aap.oppgave.OppgaveRepository
-import no.nav.aap.oppgave.ReturInformasjon
+import no.nav.aap.oppgave.ReturInfo
 import no.nav.aap.oppgave.ReturStatus
 import no.nav.aap.oppgave.enhet.IEnhetService
 import no.nav.aap.oppgave.klienter.nom.ansattinfo.AnsattInfoGateway
@@ -85,7 +85,7 @@ class OppdaterOppgaveService(
 
     private fun oppdaterOppgaver(
         oppgaveOppdatering: OppgaveOppdatering,
-        oppgaveMap: Map<AvklaringsbehovKode, OppgaveDto>,
+        oppgaveMap: Map<AvklaringsbehovKode, Oppgave>,
     ) {
         // avklaringsbehov kommer inn i riktig rekkefølge fra behandlingsflyt. Velger det første åpne
         val åpentAvklaringsbehov = oppgaveOppdatering.avklaringsbehov.firstOrNull { it.status in ÅPNE_STATUSER }
@@ -108,7 +108,7 @@ class OppdaterOppgaveService(
 
     private fun oppdaterEksistendeOppgave(
         oppgaveOppdatering: OppgaveOppdatering,
-        eksisterendeOppgave: OppgaveDto,
+        eksisterendeOppgave: Oppgave,
         avklaringsbehov: AvklaringsbehovHendelse,
     ) {
         // Send oppdatering til statistikk på slutten, så man ikke får 3 forskjellige oppdateringer
@@ -130,7 +130,7 @@ class OppdaterOppgaveService(
     private fun oppdaterOppgave(
         oppgaveOppdatering: OppgaveOppdatering,
         avklaringsbehov: AvklaringsbehovHendelse,
-        eksisterendeOppgave: OppgaveDto
+        eksisterendeOppgave: Oppgave
     ) {
         val personIdent = oppgaveOppdatering.personIdent
         val skalOverstyresTilLokalkontor = skalOverstyresTilLokalKontor(oppgaveOppdatering, avklaringsbehov)
@@ -251,7 +251,7 @@ class OppdaterOppgaveService(
         }
     }
 
-    private fun loggOppdatering(eksisterendeOppgave: OppgaveDto, årsakTilSattPåVent: String?) {
+    private fun loggOppdatering(eksisterendeOppgave: Oppgave, årsakTilSattPåVent: String?) {
         if (eksisterendeOppgave.erÅpen) {
             log.info("Oppdaterer eksisterende oppgave ${eksisterendeOppgave.oppgaveId()} på avklaringsbehov ${eksisterendeOppgave.avklaringsbehovKode}. Venteinformasjon: $årsakTilSattPåVent")
         } else {
@@ -262,13 +262,13 @@ class OppdaterOppgaveService(
     private fun utledReturInformasjon(
         avklaringsbehov: AvklaringsbehovHendelse,
         oppgaveOppdatering: OppgaveOppdatering
-    ): ReturInformasjon? {
+    ): ReturInfo? {
         return utledReturFraToTrinn(avklaringsbehov) ?: utledReturTilToTrinn(avklaringsbehov, oppgaveOppdatering)
     }
 
     private fun utledUtløptVentefrist(
         oppgaveOppdatering: OppgaveOppdatering,
-        eksisterendeOppgave: OppgaveDto,
+        eksisterendeOppgave: Oppgave,
     ): LocalDate? {
         return when {
             oppgaveTattAvVentAutomatiskIDenneOppdateringen(oppgaveOppdatering, eksisterendeOppgave) ->
@@ -285,7 +285,7 @@ class OppdaterOppgaveService(
 
     private fun oppgaveTattAvVentAutomatiskIDenneOppdateringen(
         oppgaveOppdatering: OppgaveOppdatering,
-        eksisterendeOppgave: OppgaveDto
+        eksisterendeOppgave: Oppgave
     ): Boolean {
         // Eksisterende oppgave er på vent, ventebehov med frist i dag er sist endret av Kelvin, og behandlingen er ikke lenger på vent
         return eksisterendeOppgave.påVentTil != null && oppgaveOppdatering.tattAvVentAutomatisk && oppgaveOppdatering.venteInformasjon?.frist == null
@@ -294,13 +294,13 @@ class OppdaterOppgaveService(
     private fun utledReturTilToTrinn(
         avklaringsbehov: AvklaringsbehovHendelse,
         oppgaveOppdatering: OppgaveOppdatering,
-    ): ReturInformasjon? {
+    ): ReturInfo? {
         // Setter ReturInformasjon når behandling sendes tilbake til totrinn
         return if (erReturTilToTrinn(avklaringsbehov)) {
             log.info("Totrinnsoppgave gjenåpnet, setter retur fra veileder/saksbehandler.")
             val forrigeAvklaringsbehovLøstAvVeileder =
                 oppgaveOppdatering.hvemLøsteForrigeAvklaringsbehov()?.first?.kode in AVKLARINGSBEHOV_FOR_VEILEDER.map { it.kode }
-            ReturInformasjon(
+            ReturInfo(
                 status = if (forrigeAvklaringsbehovLøstAvVeileder) {
                     ReturStatus.RETUR_FRA_VEILEDER
                 } else {
@@ -320,7 +320,7 @@ class OppdaterOppgaveService(
     }
 
     private fun avsluttOppgaverSenereIFlyt(
-        oppgaveMap: Map<AvklaringsbehovKode, OppgaveDto>,
+        oppgaveMap: Map<AvklaringsbehovKode, Oppgave>,
         åpentAvklaringsbehov: AvklaringsbehovHendelse
     ) {
         val oppgaverSomMåAvsluttes =
@@ -330,7 +330,7 @@ class OppdaterOppgaveService(
 
     private fun opprettNyOppgaveForAvklaringsbehov(
         oppgaveOppdatering: OppgaveOppdatering,
-        oppgaveMap: Map<AvklaringsbehovKode, OppgaveDto>,
+        oppgaveMap: Map<AvklaringsbehovKode, Oppgave>,
         åpentAvklaringsbehov: AvklaringsbehovHendelse
     ) {
         if (oppgaveMap.isNotEmpty()) {
@@ -360,7 +360,7 @@ class OppdaterOppgaveService(
 
     private fun utledReservasjonEtterReturFraTotrinn(
         avklaringsbehov: AvklaringsbehovHendelse,
-        eksisterendeOppgave: OppgaveDto
+        eksisterendeOppgave: Oppgave
     ) {
         val sistEndretAv = avklaringsbehov.sistEndretAv(AvklaringsbehovStatus.AVSLUTTET)
         if (sistEndretAv != KELVIN) {
@@ -377,7 +377,7 @@ class OppdaterOppgaveService(
 
     private fun utledReservasjonForGjenåpnetOppgave(
         oppgaveOppdatering: OppgaveOppdatering,
-        eksisterendeOppgave: OppgaveDto,
+        eksisterendeOppgave: Oppgave,
         avklaringsbehov: AvklaringsbehovHendelse,
     ) {
         // oppgave kan gjenåpnes uten å være sendt i retur fra totrinn - følger da samme regler for tildeling som første gang gjennom flyt
@@ -395,7 +395,7 @@ class OppdaterOppgaveService(
 
     }
 
-    private fun utledReturFraToTrinn(avklaringsbehov: AvklaringsbehovHendelse): ReturInformasjon? {
+    private fun utledReturFraToTrinn(avklaringsbehov: AvklaringsbehovHendelse): ReturInfo? {
         val status = when (avklaringsbehov.status) {
             AvklaringsbehovStatus.SENDT_TILBAKE_FRA_BESLUTTER -> ReturStatus.RETUR_FRA_BESLUTTER
             AvklaringsbehovStatus.SENDT_TILBAKE_FRA_KVALITETSSIKRER -> ReturStatus.RETUR_FRA_KVALITETSSIKRER
@@ -405,7 +405,7 @@ class OppdaterOppgaveService(
 
         val sisteEndring = avklaringsbehov.sisteEndring()
 
-        return ReturInformasjon(
+        return ReturInfo(
             status = status,
             årsaker = sisteEndring.årsakTilRetur.map { ÅrsakTilReturKode.valueOf(it.name) },
             begrunnelse = requireNotNull(sisteEndring.begrunnelse) { "Det skal alltid finnes begrunnelse for retur." },
@@ -514,7 +514,7 @@ class OppdaterOppgaveService(
         return oppgaverPåBruker.map { it.saksnummer }.firstOrNull()
     }
 
-    private fun avslutteOppgaver(oppgaver: List<OppgaveDto>) {
+    private fun avslutteOppgaver(oppgaver: List<Oppgave>) {
         oppgaver
             .filter { it.status != Status.AVSLUTTET }
             .forEach {
@@ -581,11 +581,11 @@ class OppdaterOppgaveService(
         harFortroligAdresse: Boolean,
         erSkjermet: Boolean,
         harUlesteDokumenter: Boolean,
-        returInformasjon: ReturInformasjon?,
+        returInformasjon: ReturInfo?,
         utløptVentefrist: LocalDate? = null,
         saksnummer: String? = null,
-    ): OppgaveDto {
-        return OppgaveDto(
+    ): Oppgave {
+        return Oppgave(
             personIdent = personIdent,
             saksnummer = saksnummer,
             behandlingRef = this.referanse,
@@ -609,7 +609,7 @@ class OppdaterOppgaveService(
             erSkjermet = erSkjermet,
             returStatus = returInformasjon?.status,
             returInformasjon = returInformasjon?.let {
-                ReturInformasjon(
+                ReturInfo(
                     status = it.status,
                     årsaker = it.årsaker,
                     begrunnelse = it.begrunnelse,
@@ -661,7 +661,7 @@ class OppdaterOppgaveService(
             .firstOrNull { it.status == Status.OPPRETTET }
         if (åpenOppgave?.id != null) {
             sendOppgaveStatusOppdatering(
-                oppgaveId = OppgaveId(åpenOppgave.id!!, åpenOppgave.versjon),
+                oppgaveId = OppgaveId(åpenOppgave.id, åpenOppgave.versjon),
                 hendelseType = HendelseType.OPPDATERT,
                 repository = flytJobbRepository
             )

--- a/app/src/main/kotlin/no/nav/aap/oppgave/oppdater/OppdaterOppgaveService.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/oppdater/OppdaterOppgaveService.kt
@@ -608,14 +608,7 @@ class OppdaterOppgaveService(
             harFortroligAdresse = harFortroligAdresse,
             erSkjermet = erSkjermet,
             returStatus = returInformasjon?.status,
-            returInformasjon = returInformasjon?.let {
-                ReturInfo(
-                    status = it.status,
-                    årsaker = it.årsaker,
-                    begrunnelse = it.begrunnelse,
-                    endretAv = it.endretAv
-                )
-            },
+            returInformasjon = returInformasjon,
             utløptVentefrist = utløptVentefrist,
             harUlesteDokumenter = harUlesteDokumenter
         )

--- a/app/src/main/kotlin/no/nav/aap/oppgave/oppgaveliste/HentOppgaveAPI.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/oppgaveliste/HentOppgaveAPI.kt
@@ -8,10 +8,10 @@ import com.papsign.ktor.openapigen.route.response.respondWithStatus
 import com.papsign.ktor.openapigen.route.route
 import io.ktor.http.HttpStatusCode
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
-import javax.sql.DataSource
 import no.nav.aap.behandlingsflyt.kontrakt.behandling.BehandlingReferanse
 import no.nav.aap.komponenter.dbconnect.transaction
 import no.nav.aap.komponenter.server.auth.token
+import no.nav.aap.oppgave.Oppgave
 import no.nav.aap.oppgave.OppgaveDto
 import no.nav.aap.oppgave.OppgaveRepository
 import no.nav.aap.oppgave.SøkDto
@@ -25,6 +25,7 @@ import no.nav.aap.oppgave.oppgaveliste.OppgavelisteUtils.hentPersonNavn
 import no.nav.aap.oppgave.plukk.TilgangService
 import no.nav.aap.tilgang.Operasjon
 import org.slf4j.LoggerFactory
+import javax.sql.DataSource
 
 private val log = LoggerFactory.getLogger("hentOppgaveApi")
 
@@ -48,7 +49,7 @@ fun NormalOpenAPIRoute.hentOppgaveApi(
     }
 
     if (oppgave != null) {
-        respond(oppgave.hentPersonNavn())
+        respond(oppgave.hentPersonNavn().tilOppgaveDto())
     } else {
         respondWithStatus(HttpStatusCode.NoContent)
     }
@@ -92,7 +93,7 @@ fun NormalOpenAPIRoute.søkApi(
 
         respond(
             SøkResponse(
-                oppgaver = oppgaver.hentPersonNavn(),
+                oppgaver = oppgaver.hentPersonNavn().map { it.tilOppgaveDto() },
                 harTilgang = harTilgang,
                 harAdressebeskyttelse = harAdressebeskyttelse,
             )
@@ -100,14 +101,14 @@ fun NormalOpenAPIRoute.søkApi(
     }
 }
 
-private fun harAdressebeskyttelse(oppgave: OppgaveDto): Boolean =
+private fun harAdressebeskyttelse(oppgave: Oppgave): Boolean =
     oppgave.enhet == Enhet.NAV_VIKAFOSSEN.kode ||
             erEgenAnsattEnhet(oppgave) ||
             oppgave.harFortroligAdresse == true
 
-private fun OppgaveDto.hentPersonNavn() = listOf(this).hentPersonNavn().first()
+private fun Oppgave.hentPersonNavn() = listOf(this).hentPersonNavn().first()
 
-private fun erEgenAnsattEnhet(oppgave: OppgaveDto): Boolean {
+private fun erEgenAnsattEnhet(oppgave: Oppgave): Boolean {
     // alle kontorer som slutter på 83 er egen ansatt-kontor, unntatt Nav Værnes
     return oppgave.enhet.endsWith("83") && oppgave.enhet != Enhet.NAV_VÆRNES.kode
 }

--- a/app/src/main/kotlin/no/nav/aap/oppgave/oppgaveliste/MineOppgaverAPI.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/oppgaveliste/MineOppgaverAPI.kt
@@ -51,7 +51,7 @@ fun NormalOpenAPIRoute.mineOppgaverApi(
     respond(
         OppgavelisteRespons(
             antallTotalt = mineOppgaver.size,
-            oppgaver = mineOppgaver
+            oppgaver = mineOppgaver.map { it.tilOppgaveDto() }
         )
     )
 }

--- a/app/src/main/kotlin/no/nav/aap/oppgave/oppgaveliste/OppgavelisteAPI.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/oppgaveliste/OppgavelisteAPI.kt
@@ -5,7 +5,6 @@ import com.papsign.ktor.openapigen.route.path.normal.post
 import com.papsign.ktor.openapigen.route.response.respond
 import com.papsign.ktor.openapigen.route.route
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
-import javax.sql.DataSource
 import no.nav.aap.komponenter.dbconnect.transaction
 import no.nav.aap.komponenter.server.auth.token
 import no.nav.aap.oppgave.OppgaveRepository
@@ -19,6 +18,7 @@ import no.nav.aap.oppgave.metrikker.httpCallCounter
 import no.nav.aap.oppgave.oppgaveliste.OppgavelisteUtils.hentPersonNavn
 import no.nav.aap.oppgave.server.authenticate.ident
 import org.slf4j.LoggerFactory
+import javax.sql.DataSource
 
 private val log = LoggerFactory.getLogger("oppgavelisteApi")
 
@@ -45,30 +45,32 @@ fun NormalOpenAPIRoute.oppgavelisteApi(
                     } else {
                         null
                     }
-                Pair(OppgavelisteService(
-                    oppgaveRepository = OppgaveRepository(connection),
-                    markeringRepository = MarkeringRepository(connection),
-                    norgGateway = norgGateway,
-                    enhetService = enhetService,
-                ).hentOppgaverMedTilgang(
-                    request.utvidetFilter,
-                    request.enheter,
-                    request.paging,
-                    request.kunLedigeOppgaver == true,
-                    filter,
-                    veilederIdent,
-                    token(),
-                    ident(),
-                    request.sortering?.sortBy,
-                    request.sortering?.sortOrder,
-                    request.hastemarkeringerFørst == true
-                ), filter.behandlingstyper)
+                Pair(
+                    OppgavelisteService(
+                        oppgaveRepository = OppgaveRepository(connection),
+                        markeringRepository = MarkeringRepository(connection),
+                        norgGateway = norgGateway,
+                        enhetService = enhetService,
+                    ).hentOppgaverMedTilgang(
+                        request.utvidetFilter,
+                        request.enheter,
+                        request.paging,
+                        request.kunLedigeOppgaver == true,
+                        filter,
+                        veilederIdent,
+                        token(),
+                        ident(),
+                        request.sortering?.sortBy,
+                        request.sortering?.sortOrder,
+                        request.hastemarkeringerFørst == true
+                    ), filter.behandlingstyper
+                )
             }
 
         respond(
             OppgavelisteRespons(
                 antallTotalt = data.antallTotalt,
-                oppgaver = data.oppgaver.hentPersonNavn(),
+                oppgaver = data.oppgaver.hentPersonNavn().map { it.tilOppgaveDto() },
                 antallGjenstaaende = data.antallGjenstaaende,
                 sattFilterBehandlingstyper = bruktBehanlingstyperIFilter
             )

--- a/app/src/main/kotlin/no/nav/aap/oppgave/oppgaveliste/OppgavelisteService.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/oppgaveliste/OppgavelisteService.kt
@@ -5,7 +5,7 @@ import no.nav.aap.behandlingsflyt.kontrakt.behandling.BehandlingReferanse
 import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.OidcToken
 import no.nav.aap.komponenter.miljo.Miljø
 import no.nav.aap.komponenter.miljo.MiljøKode
-import no.nav.aap.oppgave.OppgaveDto
+import no.nav.aap.oppgave.Oppgave
 import no.nav.aap.oppgave.OppgaveRepository
 import no.nav.aap.oppgave.OppgaveRepository.FinnOppgaverDto
 import no.nav.aap.oppgave.enhet.EnhetService
@@ -34,7 +34,7 @@ class OppgavelisteService(
     private val norgGateway: INorgGateway,
     private val unleashService: IUnleashService = UnleashServiceProvider.provideUnleashService(),
 ) {
-    fun søkEtterOppgaver(søketekst: String): List<OppgaveDto> {
+    fun søkEtterOppgaver(søketekst: String): List<Oppgave> {
         val oppgaver = if (søketekst.length >= 11) {
             oppgaveRepository.finnÅpneOppgaverGittPersonident(søketekst)
         } else {
@@ -47,7 +47,7 @@ class OppgavelisteService(
         }
     }
 
-    fun hentAktivOppgave(behandlingReferanse: BehandlingReferanse): OppgaveDto? {
+    fun hentAktivOppgave(behandlingReferanse: BehandlingReferanse): Oppgave? {
         val oppgave = oppgaveRepository.hentAktivOppgave(behandlingReferanse)
         if (oppgave != null) {
             val markeringer = markeringRepository.hentGjeldendeMarkeringerForBehandling(behandlingReferanse.referanse)
@@ -135,7 +135,7 @@ class OppgavelisteService(
         kunPaaVent: Boolean?,
         sortBy: OppgaveSorteringFelt?,
         sortOrder: OppgaveSorteringRekkefølge?,
-    ): List<OppgaveDto> {
+    ): List<Oppgave> {
 
         val aktivSortering = toggleAktivSortering(sortBy)
 
@@ -161,7 +161,7 @@ class OppgavelisteService(
         return if (sortBy == TILBAKEKREVINGS_BELOP && !aktivBelopSortering) null else sortBy
     }
 
-    fun hentOppgaverForBehandling(referanse: UUID): List<OppgaveDto> {
+    fun hentOppgaverForBehandling(referanse: UUID): List<Oppgave> {
         return oppgaveRepository.hentOppgaver(referanse)
     }
 
@@ -184,13 +184,13 @@ class OppgavelisteService(
         )
     }
 
-    private fun OppgaveDto.leggPåMarkeringer(markeringer: List<MarkeringDto>): OppgaveDto =
+    private fun Oppgave.leggPåMarkeringer(markeringer: List<MarkeringDto>): Oppgave =
         this.copy(markeringer = markeringer)
 
-    private fun List<OppgaveDto>.filtrerPåTilgang(
+    private fun List<Oppgave>.filtrerPåTilgang(
         token: OidcToken,
         ident: String
-    ): List<OppgaveDto> {
+    ): List<Oppgave> {
         val oppgaverFiltrertForKode7 = sjekkTilgangTilFortroligAdresse(enhetService, ident, token, this)
         val enhetsGrupper = enhetService.hentEnheter(ident, token)
         return oppgaverFiltrertForKode7
@@ -204,8 +204,8 @@ class OppgavelisteService(
         enhetService: EnhetService,
         ident: String,
         token: OidcToken,
-        oppgaver: List<OppgaveDto>
-    ): List<OppgaveDto> =
+        oppgaver: List<Oppgave>
+    ): List<Oppgave> =
         if (oppgaver.any { it.harFortroligAdresse == true } && !enhetService.kanSaksbehandleFortroligAdresse(
                 ident,
                 token

--- a/app/src/main/kotlin/no/nav/aap/oppgave/oppgaveliste/OppgavelisteUtils.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/oppgaveliste/OppgavelisteUtils.kt
@@ -2,7 +2,7 @@ package no.nav.aap.oppgave.oppgaveliste
 
 import com.github.benmanes.caffeine.cache.Caffeine
 import io.micrometer.core.instrument.binder.cache.CaffeineCacheMetrics
-import no.nav.aap.oppgave.OppgaveDto
+import no.nav.aap.oppgave.Oppgave
 import no.nav.aap.oppgave.klienter.pdl.PdlGraphqlGateway
 import no.nav.aap.oppgave.metrikker.prometheus
 import org.flywaydb.core.api.logging.LogFactory
@@ -24,7 +24,7 @@ object OppgavelisteUtils {
         CaffeineCacheMetrics.monitor(prometheus, personinfoCache, "oppgave_navn")
     }
 
-    fun List<OppgaveDto>.hentPersonNavn(): List<OppgaveDto> {
+    fun List<Oppgave>.hentPersonNavn(): List<Oppgave> {
         val identer = mapNotNull { it.personIdent }.distinct()
         if (identer.isEmpty()) {
             return this
@@ -71,10 +71,10 @@ object OppgavelisteUtils {
             ?: emptyList()
     }
 
-    private fun OppgaveDto.medNavn(
+    private fun Oppgave.medNavn(
         ident: String?,
         samletNavnMap: Map<String, String?>
-    ): OppgaveDto {
+    ): Oppgave {
         val personNavn = ident?.let { samletNavnMap[it] } ?: ""
 
         return this.copy(personNavn = personNavn)

--- a/app/src/main/kotlin/no/nav/aap/oppgave/plukk/PlukkAPI.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/plukk/PlukkAPI.kt
@@ -35,7 +35,7 @@ fun NormalOpenAPIRoute.plukkOppgaveApi(
         prometheus.httpCallCounter("/plukk-oppgave").increment()
         val oppgave = PlukkOppgaveService.plukkOppgave(dataSource, enhetService, ansattInfoGateway, token(), ident(), request.oppgaveId)
         if (oppgave != null) {
-            respond(oppgave)
+            respond(oppgave.tilOppgaveDto())
         } else {
             log.info("Bruker kunne ikke plukke oppgave")
             respondWithStatus(HttpStatusCode.Unauthorized)

--- a/app/src/main/kotlin/no/nav/aap/oppgave/plukk/PlukkOppgaveService.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/plukk/PlukkOppgaveService.kt
@@ -8,7 +8,7 @@ import no.nav.aap.motor.FlytJobbRepository
 import no.nav.aap.motor.FlytJobbRepositoryImpl
 import no.nav.aap.oppgave.AVKLARINGSBEHOV_FOR_VEILEDER_OG_SAKSBEHANDLER
 import no.nav.aap.oppgave.AvklaringsbehovKode
-import no.nav.aap.oppgave.OppgaveDto
+import no.nav.aap.oppgave.Oppgave
 import no.nav.aap.oppgave.OppgaveId
 import no.nav.aap.oppgave.OppgaveRepository
 import no.nav.aap.oppgave.enhet.IEnhetService
@@ -106,7 +106,7 @@ class PlukkOppgaveService(
             token: OidcToken,
             ident: String,
             oppgaveId: Long,
-        ): OppgaveDto? {
+        ): Oppgave? {
             val oppgave = dataSource.transaction(readOnly = true) {
                 OppgaveRepository(it).hentOppgave(oppgaveId)
             }

--- a/app/src/main/kotlin/no/nav/aap/oppgave/prosessering/StatistikkHendelseJobb.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/prosessering/StatistikkHendelseJobb.kt
@@ -6,7 +6,7 @@ import no.nav.aap.motor.FlytJobbRepository
 import no.nav.aap.motor.Jobb
 import no.nav.aap.motor.JobbInput
 import no.nav.aap.motor.JobbUtfører
-import no.nav.aap.oppgave.OppgaveDto
+import no.nav.aap.oppgave.Oppgave
 import no.nav.aap.oppgave.OppgaveId
 import no.nav.aap.oppgave.OppgaveRepository
 import no.nav.aap.oppgave.markering.BehandlingMarkering
@@ -33,7 +33,7 @@ class StatistikkHendelseJobb(
             StatistikkGateway.avgiHendelse(
                 OppgaveHendelse(
                     hendelse = hendelsesType,
-                    oppgaveTilStatistikkDto = fraOppgaveDto(oppgaveDto, markeringer),
+                    oppgaveTilStatistikkDto = fraOppgave(oppgaveDto, markeringer),
                     sendtTidspunkt = LocalDateTime.now()
                 )
             )
@@ -59,24 +59,24 @@ class StatistikkHendelseJobb(
     }
 }
 
-private fun fraOppgaveDto(oppgaveDto: OppgaveDto, markeringer: List<BehandlingMarkering>): OppgaveTilStatistikkDto {
+private fun fraOppgave(oppgave: Oppgave, markeringer: List<BehandlingMarkering>): OppgaveTilStatistikkDto {
     return OppgaveTilStatistikkDto(
-        id = oppgaveDto.id,
-        personIdent = oppgaveDto.personIdent,
-        saksnummer = oppgaveDto.saksnummer,
-        behandlingRef = oppgaveDto.behandlingRef,
-        journalpostId = oppgaveDto.journalpostId,
-        enhet = oppgaveDto.enhetForKø,
-        avklaringsbehovKode = oppgaveDto.avklaringsbehovKode,
-        status = oppgaveDto.status,
-        behandlingstype = oppgaveDto.behandlingstype,
-        reservertAv = oppgaveDto.reservertAv,
-        reservertTidspunkt = oppgaveDto.reservertTidspunkt,
-        opprettetAv = oppgaveDto.opprettetAv,
-        opprettetTidspunkt = oppgaveDto.opprettetTidspunkt,
-        endretAv = oppgaveDto.endretAv,
-        endretTidspunkt = oppgaveDto.endretTidspunkt,
-        versjon = oppgaveDto.versjon,
+        id = oppgave.id,
+        personIdent = oppgave.personIdent,
+        saksnummer = oppgave.saksnummer,
+        behandlingRef = oppgave.behandlingRef,
+        journalpostId = oppgave.journalpostId,
+        enhet = oppgave.enhetForKø,
+        avklaringsbehovKode = oppgave.avklaringsbehovKode,
+        status = oppgave.status,
+        behandlingstype = oppgave.behandlingstype,
+        reservertAv = oppgave.reservertAv,
+        reservertTidspunkt = oppgave.reservertTidspunkt,
+        opprettetAv = oppgave.opprettetAv,
+        opprettetTidspunkt = oppgave.opprettetTidspunkt,
+        endretAv = oppgave.endretAv,
+        endretTidspunkt = oppgave.endretTidspunkt,
+        versjon = oppgave.versjon,
         harHasteMarkering = markeringer.any { it.markeringType === MarkeringForBehandling.HASTER },
         harAvslagSykdomMarkering = markeringer.any { it.markeringType === MarkeringForBehandling.AVSLAG_11_5 }
     )

--- a/app/src/main/kotlin/no/nav/aap/oppgave/prosessering/StatistikkHendelseJobb.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/prosessering/StatistikkHendelseJobb.kt
@@ -28,12 +28,12 @@ class StatistikkHendelseJobb(
         val hendelsesType = HendelseType.valueOf(input.parameter("hendelsesType"))
         val oppgaveId = DefaultJsonMapper.fromJson<OppgaveId>(input.payload())
 
-        oppgaveRepository.hentOppgave(oppgaveId.id).let { oppgaveDto ->
-            val markeringer = markeringRepository.hentGjeldendeMarkeringerForBehandling(oppgaveDto.behandlingRef)
+        oppgaveRepository.hentOppgave(oppgaveId.id).let { oppgave ->
+            val markeringer = markeringRepository.hentGjeldendeMarkeringerForBehandling(oppgave.behandlingRef)
             StatistikkGateway.avgiHendelse(
                 OppgaveHendelse(
                     hendelse = hendelsesType,
-                    oppgaveTilStatistikkDto = fraOppgave(oppgaveDto, markeringer),
+                    oppgaveTilStatistikkDto = fraOppgave(oppgave, markeringer),
                     sendtTidspunkt = LocalDateTime.now()
                 )
             )

--- a/app/src/main/kotlin/no/nav/aap/oppgave/prosessering/VarsleOmOppgaverIkkeEndretJobb.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/prosessering/VarsleOmOppgaverIkkeEndretJobb.kt
@@ -25,7 +25,7 @@ class VarsleOmOppgaverIkkeEndretJobb(
         log.info("Fant ${alleÅpneOppgaverIkkePåVent.size} åpne oppgaver som ikke er på vent og ikke er reservert.")
         val nå = LocalDateTime.now()
         val oppgaverIkkeEndretPåFemUker = alleÅpneOppgaverIkkePåVent.filter {
-            (it.endretTidspunkt != null && it.endretTidspunkt!! < nå.minusWeeks(5)) || (it.endretTidspunkt == null && it.opprettetTidspunkt < nå.minusWeeks(
+            (it.endretTidspunkt != null && it.endretTidspunkt < nå.minusWeeks(5)) || (it.endretTidspunkt == null && it.opprettetTidspunkt < nå.minusWeeks(
                 5
             ))
         }

--- a/app/src/test/kotlin/no/nav/aap/oppgave/OppgaveApiTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/oppgave/OppgaveApiTest.kt
@@ -1547,14 +1547,7 @@ class OppgaveApiTest {
                     veilederSykdom = oppgave.veilederSykdom,
                     vurderingsbehov = oppgave.årsakerTilBehandling,
                     erSkjermet = oppgave.erSkjermet == true,
-                    returInformasjon = oppgave.returInformasjon?.let {
-                        ReturInfo(
-                            status = it.status,
-                            årsaker = it.årsaker,
-                            begrunnelse = it.begrunnelse,
-                            endretAv = it.endretAv
-                        )
-                    },
+                    returInformasjon = oppgave.returInformasjon,
                     utløptVentefrist = oppgave.utløptVentefrist
                 )
             }

--- a/app/src/test/kotlin/no/nav/aap/oppgave/OppgaveApiTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/oppgave/OppgaveApiTest.kt
@@ -536,7 +536,7 @@ class OppgaveApiTest {
         reserverOppgave(oppgave2!!.oppgaveId(), "saksbehandler2", "saksbehandler2")
 
         // kall endepunkt for avreservering
-        val avreserverteOppgaveIds = avreserverOppgaver(listOf(oppgave1.id!!, oppgave2.id!!))
+        val avreserverteOppgaveIds = avreserverOppgaver(listOf(oppgave1.id, oppgave2.id))
         val avreserverteOppgaver = avreserverteOppgaveIds?.map { hentOppgaveViaRepository(it) }
 
         assertThat(avreserverteOppgaver).hasSize(2)
@@ -598,20 +598,20 @@ class OppgaveApiTest {
         assertThat(naySaksbehandlere?.first()?.navIdent).isEqualTo("NayVeileder123")
 
         // Søk på å tildele både en NAY-oppgave og en kontor-oppgave skal returnere kun saksbehandlere som har tilgang til en av dem
-        val alleSaksbehandlere = søkEtterSaksbehandlere("Test", listOf(oppgave.id!!, oppgave2.id!!))?.saksbehandlere
+        val alleSaksbehandlere = søkEtterSaksbehandlere("Test", listOf(oppgave.id, oppgave2.id))?.saksbehandlere
         assertThat(alleSaksbehandlere).hasSize(2)
 
         // Når ingen matcher returneres tom liste
-        val ingenSaksbehandlere = søkEtterSaksbehandlere("xxxxx", listOf(oppgave.id!!, oppgave2.id!!))?.saksbehandlere
+        val ingenSaksbehandlere = søkEtterSaksbehandlere("xxxxx", listOf(oppgave.id, oppgave2.id))?.saksbehandlere
         assertThat(ingenSaksbehandlere).isEmpty()
 
         // Kan søke på fullt navn
-        val naySaksbehandler = søkEtterSaksbehandlere("test naysen", listOf(oppgave2.id!!))?.saksbehandlere
+        val naySaksbehandler = søkEtterSaksbehandlere("test naysen", listOf(oppgave2.id))?.saksbehandlere
         assertThat(naySaksbehandler).hasSize(1)
         assertThat(naySaksbehandler?.first()?.navIdent).isEqualTo("NayVeileder123")
 
         // Kan søke på NAV-ident
-        val naySaksbehandlerIdent = søkEtterSaksbehandlere("nayveileder123", listOf(oppgave2.id!!))?.saksbehandlere
+        val naySaksbehandlerIdent = søkEtterSaksbehandlere("nayveileder123", listOf(oppgave2.id))?.saksbehandlere
         assertThat(naySaksbehandlerIdent).hasSize(1)
         assertThat(naySaksbehandlerIdent?.first()?.navIdent).isEqualTo("NayVeileder123")
 
@@ -794,6 +794,7 @@ class OppgaveApiTest {
         oppdaterOgHentOppgave(
             Oppgave(
                 id = opprettetOppgave!!.id,
+                personIdent = "123",
                 saksnummer = opprettetOppgave.saksnummer,
                 behandlingRef = opprettetOppgave.behandlingRef,
                 enhet = Enhet.NAV_VIKAFOSSEN.kode,
@@ -816,6 +817,7 @@ class OppgaveApiTest {
         oppdaterOgHentOppgave(
             Oppgave(
                 id = opprettetOppgave.id,
+                personIdent = "123",
                 saksnummer = opprettetOppgave.saksnummer,
                 behandlingRef = opprettetOppgave.behandlingRef,
                 enhet = Enhet.NAV_VIKAFOSSEN.kode,
@@ -838,6 +840,7 @@ class OppgaveApiTest {
         oppdaterOgHentOppgave(
             Oppgave(
                 id = opprettetOppgave.id,
+                personIdent = "123",
                 saksnummer = opprettetOppgave.saksnummer,
                 behandlingRef = opprettetOppgave.behandlingRef,
                 enhet = Enhet.NAY_EGNE_ANSATTE.kode,

--- a/app/src/test/kotlin/no/nav/aap/oppgave/OppgaveApiTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/oppgave/OppgaveApiTest.kt
@@ -51,8 +51,6 @@ import no.nav.aap.oppgave.fakes.STRENGT_FORTROLIG_IDENT
 import no.nav.aap.oppgave.klienter.pdl.PdlGraphqlGateway
 import no.nav.aap.oppgave.liste.OppgavelisteRespons
 import no.nav.aap.oppgave.markering.MarkeringDto
-import no.nav.aap.oppgave.markering.MarkeringRepository
-import no.nav.aap.oppgave.oppdater.MarkeringService
 import no.nav.aap.oppgave.plukk.PlukkOppgaveDto
 import no.nav.aap.oppgave.produksjonsstyring.AntallOppgaverDto
 import no.nav.aap.oppgave.prosessering.OppdaterOppgaveEnhetJobb
@@ -121,12 +119,12 @@ class OppgaveApiTest {
         )
 
         // Hent oppgaven som ble opprettet
-        val oppgave = hentOppgave(referanse)
+        val oppgave = hentOppgaveViaAPI(referanse)
         assertThat(oppgave).isNotNull
         assertThat(oppgave!!.enhet).isEqualTo("superNav!")
 
         // Hent hele oppgaven
-        val oppgaven = hentOppgave(oppgave.oppgaveId())
+        val oppgaven = hentOppgaveViaRepository(oppgave.oppgaveId())
         assertThat(oppgaven.årsakerTilBehandling).containsExactly("SØKNAD")
         assertThat(oppgaven.vurderingsbehov).containsExactly("SØKNAD")
 
@@ -148,7 +146,7 @@ class OppgaveApiTest {
         )
 
         // Sjekk at oppgaven er avsluttet
-        val avsluttetOppgave = hentOppgave(oppgave.oppgaveId())
+        val avsluttetOppgave = hentOppgaveViaRepository(oppgave.oppgaveId())
         assertThat(avsluttetOppgave.status).isEqualTo(no.nav.aap.oppgave.verdityper.Status.AVSLUTTET)
     }
 
@@ -173,7 +171,7 @@ class OppgaveApiTest {
         )
 
         // Hent oppgaven som ble opprettet
-        val oppgave = hentOppgave(referanse)
+        val oppgave = hentOppgaveViaAPI(referanse)
         assertThat(oppgave).isNotNull
         assertThat(oppgave!!.enhet).isEqualTo("4491")
         assertThat(oppgave.vurderingsbehov).contains("SØKNAD")
@@ -198,7 +196,7 @@ class OppgaveApiTest {
         )
 
         // Sjekk at oppgave er avsluttet
-        val avsluttetOppgave = hentOppgave(oppgave.oppgaveId())
+        val avsluttetOppgave = hentOppgaveViaRepository(oppgave.oppgaveId())
         assertThat(avsluttetOppgave.status).isEqualTo(no.nav.aap.oppgave.verdityper.Status.AVSLUTTET)
     }
 
@@ -235,18 +233,18 @@ class OppgaveApiTest {
             )
         )
 
-        val påVentOppgaver = hentOppgave(
+        val påVentOppgaver = hentOppgaveViaAPI(
             referanse = referanse
         )!!
         assertThat(påVentOppgaver)
             .extracting(OppgaveDto::påVentÅrsak, OppgaveDto::venteBegrunnelse)
             .containsExactly(ÅrsakTilSettPåVent.VENTER_PÅ_MEDISINSKE_OPPLYSNINGER.name, "Bedre ting å gjøre")
 
-        val uthentetPåVent = hentOppgave(
+        val uthentetPåVent = hentOppgaveViaRepository(
             påVentOppgaver.oppgaveId()
         )
         assertThat(uthentetPåVent)
-            .extracting(OppgaveDto::venteBegrunnelse, OppgaveDto::påVentTil, OppgaveDto::påVentÅrsak)
+            .extracting(Oppgave::venteBegrunnelse, Oppgave::påVentTil, Oppgave::påVentÅrsak)
             .containsExactly(
                 "Bedre ting å gjøre",
                 LocalDate.now().plusWeeks(2),
@@ -283,7 +281,7 @@ class OppgaveApiTest {
             )
         )
 
-        val uthentet = hentOppgave(referanse)
+        val uthentet = hentOppgaveViaAPI(referanse)
         assertThat(uthentet).isNotNull
         assertThat(uthentet!!)
             .extracting(OppgaveDto::venteBegrunnelse, OppgaveDto::påVentTil, OppgaveDto::påVentÅrsak)
@@ -313,11 +311,11 @@ class OppgaveApiTest {
             )
         )
 
-        val oppgaveDto = hentOppgave(
+        val oppgave = hentOppgaveViaAPI(
             referanse = referanse
         )!!
 
-        assertThat(oppgaveDto.reservertAv)
+        assertThat(oppgave.reservertAv)
             .withFailMessage { "reserverTil skal implisere at oppgaven blir reservert til denne personen" }
             .isEqualTo("U12345")
     }
@@ -417,7 +415,7 @@ class OppgaveApiTest {
             )
         )
 
-        val oppgave = hentOppgave(referanse)
+        val oppgave = hentOppgaveViaAPI(referanse)
 
         fakesConfig.negativtSvarFraTilgangForBehandling = setOf()
         val nesteOppgave = plukkOppgave(oppgave!!.oppgaveId())
@@ -443,7 +441,7 @@ class OppgaveApiTest {
             )
         )
 
-        val oppgave = hentOppgave(referanse)
+        val oppgave = hentOppgaveViaAPI(referanse)
 
         fakesConfig.negativtSvarFraTilgangForBehandling = setOf(referanse)
         assertThrows<ManglerTilgangException> { plukkOppgave(oppgave!!.oppgaveId()) }
@@ -470,8 +468,8 @@ class OppgaveApiTest {
         )
 
         // reserverer oppgave
-        plukkOppgave(hentOppgave(referanse)!!.oppgaveId())
-        val reservertOppgaveMedTilgang = hentOppgave(
+        plukkOppgave(hentOppgaveViaAPI(referanse)!!.oppgaveId())
+        val reservertOppgaveMedTilgang = hentOppgaveViaAPI(
             referanse = referanse,
         )
         assertThat(reservertOppgaveMedTilgang).isNotNull()
@@ -489,7 +487,7 @@ class OppgaveApiTest {
 
         // sjekk at reservasjon er fjernet
         val oppgaveUtenReservasjon =
-            hentOppgave(reservertOppgaveMedTilgang!!.oppgaveId())
+            hentOppgaveViaRepository(reservertOppgaveMedTilgang!!.oppgaveId())
         assertThat(oppgaveUtenReservasjon).isNotNull()
         assertThat(oppgaveUtenReservasjon.reservertAv == null)
         assertThat(oppgaveUtenReservasjon.reservertTidspunkt == null)
@@ -532,14 +530,14 @@ class OppgaveApiTest {
         )
 
         // reserverer begge oppgaver
-        val oppgave1 = hentOppgave(referanse1)
-        val oppgave2 = hentOppgave(referanse2)
+        val oppgave1 = hentOppgaveViaAPI(referanse1)
+        val oppgave2 = hentOppgaveViaAPI(referanse2)
         reserverOppgave(oppgave1!!.oppgaveId(), "saksbehandler1", "saksbehandler1")
         reserverOppgave(oppgave2!!.oppgaveId(), "saksbehandler2", "saksbehandler2")
 
         // kall endepunkt for avreservering
         val avreserverteOppgaveIds = avreserverOppgaver(listOf(oppgave1.id!!, oppgave2.id!!))
-        val avreserverteOppgaver = avreserverteOppgaveIds?.map { hentOppgave(it) }
+        val avreserverteOppgaver = avreserverteOppgaveIds?.map { hentOppgaveViaRepository(it) }
 
         assertThat(avreserverteOppgaver).hasSize(2)
         assertThat(avreserverteOppgaver?.all { it.reservertAv == null && it.reservertTidspunkt == null })
@@ -566,7 +564,7 @@ class OppgaveApiTest {
             )
         )
 
-        val oppgave = hentOppgave(referanse1)
+        val oppgave = hentOppgaveViaAPI(referanse1)
 
         // Søk på å tildele en 11-5-oppgave skal bare returnere veiledere med tilgang til enheten
         val lokalSaksbehandlere = søkEtterSaksbehandlere("Kontorsen", listOf(oppgave?.id!!))?.saksbehandlere
@@ -592,7 +590,7 @@ class OppgaveApiTest {
         )
 
 
-        val oppgave2 = hentOppgave(referanse2)
+        val oppgave2 = hentOppgaveViaAPI(referanse2)
 
         // Søk på å tildele en 11-19-oppgave skal bare returnere den NAY-saksbehandleren med enhetstilgang
         val naySaksbehandlere = søkEtterSaksbehandlere("Naysen", listOf(oppgave2?.id!!))?.saksbehandlere
@@ -655,20 +653,20 @@ class OppgaveApiTest {
             )
         )
 
-        val oppgave1 = hentOppgave(referanse1)
-        val oppgave2 = hentOppgave(referanse2)
+        val oppgave1 = hentOppgaveViaAPI(referanse1)
+        val oppgave2 = hentOppgaveViaAPI(referanse2)
 
         tildelOppgaver(listOf(oppgave1?.id!!, oppgave2?.id!!), ident = "saksbehandler")
 
-        val oppgave1EtterReservering = hentOppgave(referanse1)
-        val oppgave2EtterReservering = hentOppgave(referanse2)
+        val oppgave1EtterReservering = hentOppgaveViaAPI(referanse1)
+        val oppgave2EtterReservering = hentOppgaveViaAPI(referanse2)
         assertThat(oppgave1EtterReservering?.reservertAv).isEqualTo("saksbehandler")
         assertThat(oppgave2EtterReservering?.reservertAv).isEqualTo("saksbehandler")
 
         // kan tildele oppgave på nytt, selv om den nå er reservert av noen
         tildelOppgaver(listOf(oppgave1EtterReservering?.id!!), ident = "saksbehandler2")
 
-        val oppgave1Igjen = hentOppgave(referanse1)
+        val oppgave1Igjen = hentOppgaveViaAPI(referanse1)
         assertThat(oppgave1Igjen?.reservertAv).isEqualTo("saksbehandler2")
 
     }
@@ -693,12 +691,12 @@ class OppgaveApiTest {
         )
 
 
-        val oppgaveMedGammelEnhet = hentOppgave(referanse)
+        val oppgaveMedGammelEnhet = hentOppgaveViaAPI(referanse)
         assertThat(oppgaveMedGammelEnhet).isNotNull()
 
         // oppdater enhet på oppgave
         val oppgaveMedNyEnhet = oppdaterOgHentOppgave(
-            OppgaveDto(
+            Oppgave(
                 id = oppgaveMedGammelEnhet!!.id,
                 saksnummer = oppgaveMedGammelEnhet.saksnummer,
                 behandlingRef = oppgaveMedGammelEnhet.behandlingRef,
@@ -725,7 +723,7 @@ class OppgaveApiTest {
         )
 
         // enhet skal ha blitt oppdatert etter mislykket plukk
-        val oppgaveEtterOppdatering = hentOppgave(oppgaveMedNyEnhet.oppgaveId())
+        val oppgaveEtterOppdatering = hentOppgaveViaRepository(oppgaveMedNyEnhet.oppgaveId())
         assertThat(oppgaveEtterOppdatering).isNotNull()
         assertThat(oppgaveEtterOppdatering.enhet).isEqualTo("superNav!")
         assertThat(oppgaveEtterOppdatering.oppfølgingsenhet).isNull()
@@ -752,7 +750,7 @@ class OppgaveApiTest {
         )
 
 
-        val oppgaveMedGammelEnhet = hentOppgave(referanse)
+        val oppgaveMedGammelEnhet = hentOppgaveViaAPI(referanse)
         assertThat(oppgaveMedGammelEnhet).isNotNull()
 
         // plukk uten tilgang - det har kommet ny relatert ident på sak fra behandlingsflyt-pip
@@ -763,7 +761,7 @@ class OppgaveApiTest {
         )
 
         // enhet skal ha blitt oppdatert med hensyn til relatert ident etter mislykket plukk
-        val oppgaveEtterOppdatering = hentOppgave(oppgaveMedGammelEnhet!!.oppgaveId())
+        val oppgaveEtterOppdatering = hentOppgaveViaRepository(oppgaveMedGammelEnhet!!.oppgaveId())
         assertThat(oppgaveEtterOppdatering).isNotNull()
         assertThat(oppgaveEtterOppdatering.enhet).isEqualTo(Enhet.NAV_VIKAFOSSEN.kode)
         assertThat(oppgaveEtterOppdatering.oppfølgingsenhet).isNull()
@@ -788,13 +786,13 @@ class OppgaveApiTest {
             )
         )
 
-        val opprettetOppgave = hentOppgave(
+        val opprettetOppgave = hentOppgaveViaAPI(
             referanse = referanse1,
         )
 
         // sett strengt fortrolig adresse
         oppdaterOgHentOppgave(
-            OppgaveDto(
+            Oppgave(
                 id = opprettetOppgave!!.id,
                 saksnummer = opprettetOppgave.saksnummer,
                 behandlingRef = opprettetOppgave.behandlingRef,
@@ -816,7 +814,7 @@ class OppgaveApiTest {
 
         // sett fortrolig adresse
         oppdaterOgHentOppgave(
-            OppgaveDto(
+            Oppgave(
                 id = opprettetOppgave.id,
                 saksnummer = opprettetOppgave.saksnummer,
                 behandlingRef = opprettetOppgave.behandlingRef,
@@ -838,7 +836,7 @@ class OppgaveApiTest {
 
         // sett egen ansatt
         oppdaterOgHentOppgave(
-            OppgaveDto(
+            Oppgave(
                 id = opprettetOppgave.id,
                 saksnummer = opprettetOppgave.saksnummer,
                 behandlingRef = opprettetOppgave.behandlingRef,
@@ -879,7 +877,7 @@ class OppgaveApiTest {
             )
         )
 
-        val oppgaveUtenFortroligAdresse = hentOppgave(referanse1)
+        val oppgaveUtenFortroligAdresse = hentOppgaveViaAPI(referanse1)
         assertThat(oppgaveUtenFortroligAdresse).isNotNull()
 
         // sett fortrolig adresse
@@ -888,7 +886,7 @@ class OppgaveApiTest {
         )
 
         // hent på nytt
-        val oppgaveMedFortroligAdresse = hentOppgave(
+        val oppgaveMedFortroligAdresse = hentOppgaveViaRepository(
             oppgaveUtenFortroligAdresse.oppgaveId()
         )
         assertThat(oppgaveMedFortroligAdresse.harFortroligAdresse).isTrue()
@@ -1027,7 +1025,7 @@ class OppgaveApiTest {
         // Oppgaven er gjenopprettet
         assertThat(hentAntallOppgaver().keys).hasSize(1)
 
-        val oppgaven = hentOppgave(referanse1)!!
+        val oppgaven = hentOppgaveViaAPI(referanse1)!!
 
         assertThat(oppgaven).extracting(OppgaveDto::returInformasjon)
             .isNotNull
@@ -1046,7 +1044,7 @@ class OppgaveApiTest {
     fun `Skal avreservere og flytte oppgaver til Vikafossen dersom person har fått strengt fortrolig adresse`() {
         val oppgaveId1 = opprettOppgave(personIdent = STRENGT_FORTROLIG_IDENT)
         val oppgaveId2 = opprettOppgave()
-        val oppgave2Før = hentOppgave(oppgaveId2)
+        val oppgave2Før = hentOppgaveViaRepository(oppgaveId2)
 
         initDatasource(dbConfig(), prometheus).transaction {
             OppdaterOppgaveEnhetJobb(
@@ -1060,11 +1058,11 @@ class OppgaveApiTest {
             )
         }
 
-        val oppgave1 = hentOppgave(oppgaveId1)
+        val oppgave1 = hentOppgaveViaRepository(oppgaveId1)
         assertEquals(Enhet.NAV_VIKAFOSSEN.kode, oppgave1.enhet)
         assertNull(oppgave1.reservertAv)
         assertEquals(oppgave1.endretAv, "Kelvin")
-        val oppgave2Etter = hentOppgave(oppgaveId2)
+        val oppgave2Etter = hentOppgaveViaRepository(oppgaveId2)
         assertEquals(oppgave2Før, oppgave2Etter)
     }
 
@@ -1144,7 +1142,7 @@ class OppgaveApiTest {
         opprettMarkeringHendelse(behandlingref, markering)
 
         // reserver og hent mine oppgaver
-        plukkOppgave(hentOppgave(behandlingref)!!.oppgaveId())
+        plukkOppgave(hentOppgaveViaAPI(behandlingref)!!.oppgaveId())
         val mineOppgaver = hentMineOppgaver()
         assertThat(mineOppgaver.oppgaver).hasSize(1)
         assertThat(mineOppgaver.oppgaver.first().markeringer).hasSize(1)
@@ -1186,7 +1184,7 @@ class OppgaveApiTest {
         opprettMarkeringHendelse(behandlingref, markeringOpprettet)
 
         // reserver
-        plukkOppgave(hentOppgave(behandlingref)!!.oppgaveId())
+        plukkOppgave(hentOppgaveViaAPI(behandlingref)!!.oppgaveId())
 
         // fjern markering
         val markeringFjernet = MarkeringDto(
@@ -1435,7 +1433,7 @@ class OppgaveApiTest {
         )
     }
 
-    private fun hentOppgave(referanse: UUID): OppgaveDto? {
+    private fun hentOppgaveViaAPI(referanse: UUID): OppgaveDto? {
         return oboClient.get(
             URI.create("http://localhost:$port/${referanse}/hent-oppgave"),
             GetRequest(
@@ -1513,7 +1511,7 @@ class OppgaveApiTest {
             }
         }
 
-        private fun hentOppgave(oppgaveId: OppgaveId): OppgaveDto {
+        private fun hentOppgaveViaRepository(oppgaveId: OppgaveId): Oppgave {
             return initDatasource(dbConfig(), prometheus).transaction { connection ->
                 OppgaveRepository(connection).hentOppgave(oppgaveId.id)
             }
@@ -1534,7 +1532,7 @@ class OppgaveApiTest {
             }
         }
 
-        private fun oppdaterOgHentOppgave(oppgave: OppgaveDto): OppgaveDto {
+        private fun oppdaterOgHentOppgave(oppgave: Oppgave): Oppgave {
             initDatasource(dbConfig(), prometheus).transaction { connection ->
                 OppgaveRepository(connection).oppdatereOppgave(
                     oppgaveId = oppgave.oppgaveId(),
@@ -1549,11 +1547,18 @@ class OppgaveApiTest {
                     veilederSykdom = oppgave.veilederSykdom,
                     vurderingsbehov = oppgave.årsakerTilBehandling,
                     erSkjermet = oppgave.erSkjermet == true,
-                    returInformasjon = oppgave.returInformasjon,
+                    returInformasjon = oppgave.returInformasjon?.let {
+                        ReturInfo(
+                            status = it.status,
+                            årsaker = it.årsaker,
+                            begrunnelse = it.begrunnelse,
+                            endretAv = it.endretAv
+                        )
+                    },
                     utløptVentefrist = oppgave.utløptVentefrist
                 )
             }
-            return hentOppgave(oppgave.oppgaveId())
+            return hentOppgaveViaRepository(oppgave.oppgaveId())
         }
 
         private fun opprettOppgave(
@@ -1568,7 +1573,7 @@ class OppgaveApiTest {
             veilederArbeid: String? = null,
             veilederSykdom: String? = null,
         ): OppgaveId {
-            val oppgaveDto = OppgaveDto(
+            val oppgave = Oppgave(
                 personIdent = personIdent,
                 saksnummer = saksnummer,
                 behandlingRef = behandlingRef,
@@ -1584,7 +1589,7 @@ class OppgaveApiTest {
                 opprettetTidspunkt = LocalDateTime.now()
             )
             return initDatasource(dbConfig(), prometheus).transaction { connection ->
-                OppgaveRepository(connection).opprettOppgave(oppgaveDto)
+                OppgaveRepository(connection).opprettOppgave(oppgave)
             }
         }
 

--- a/app/src/test/kotlin/no/nav/aap/oppgave/OppgaveRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/oppgave/OppgaveRepositoryTest.kt
@@ -624,13 +624,13 @@ class OppgaveRepositoryTest {
             enhet = ENHET_NAV_ENEBAKK,
             avklaringsbehovKode = AvklaringsbehovKode("5003"),
             påVentÅrsak = "VENTER_PÅ_SVAR_FRA_BRUKER",
-            returInformasjon = ReturInformasjon(ReturStatus.RETUR_FRA_BESLUTTER, listOf(), "", "")
+            returInformasjon = ReturInfo(ReturStatus.RETUR_FRA_BESLUTTER, listOf(), "", "")
         )
         val hasterBehandlingsref = UUID.randomUUID()
         val hasteOppgave = opprettOppgave(
             enhet = ENHET_NAV_ENEBAKK,
             avklaringsbehovKode = AvklaringsbehovKode("5003"),
-            returInformasjon = ReturInformasjon(ReturStatus.RETUR_FRA_BESLUTTER, listOf(), "", ""),
+            returInformasjon = ReturInfo(ReturStatus.RETUR_FRA_BESLUTTER, listOf(), "", ""),
             behandlingRef = hasterBehandlingsref
         )
         markerHasteOppgave(hasterBehandlingsref)
@@ -1286,7 +1286,7 @@ class OppgaveRepositoryTest {
         }
     }
 
-    private fun mineOppgaver(ident: String): List<OppgaveDto> {
+    private fun mineOppgaver(ident: String): List<Oppgave> {
         return dataSource.transaction { connection ->
             OppgaveRepository(connection).hentMineOppgaver(ident)
         }
@@ -1371,7 +1371,7 @@ class OppgaveRepositoryTest {
         }
     }
 
-    private fun finnOppgaverForSak(saksnummer: String): List<OppgaveDto> {
+    private fun finnOppgaverForSak(saksnummer: String): List<Oppgave> {
         return dataSource.transaction(readOnly = true) { connection ->
             OppgaveRepository(connection).finnOppgaverGittSaksnummer(saksnummer)
         }
@@ -1406,7 +1406,7 @@ class OppgaveRepositoryTest {
         }
     }
 
-    private fun settUtløptVentefrist(oppgave: OppgaveDto, utløptVentefrist: LocalDate?) {
+    private fun settUtløptVentefrist(oppgave: Oppgave, utløptVentefrist: LocalDate?) {
         return dataSource.transaction { connection ->
             OppgaveRepository(connection).oppdatereOppgave(
                 oppgaveId = oppgave.oppgaveId(),
@@ -1429,7 +1429,7 @@ class OppgaveRepositoryTest {
         }
     }
 
-    private fun hentOppgave(oppgaveId: OppgaveId): OppgaveDto {
+    private fun hentOppgave(oppgaveId: OppgaveId): Oppgave {
         return dataSource.transaction { connection ->
             OppgaveRepository(connection).hentOppgave(oppgaveId.id)
         }
@@ -1449,11 +1449,11 @@ class OppgaveRepositoryTest {
         påVentÅrsak: String? = null,
         venteBegrunnelse: String? = null,
         harUlesteDokumenter: Boolean = false,
-        returInformasjon: ReturInformasjon? = null,
+        returInformasjon: ReturInfo? = null,
         årsakTilOpprettelse: String? = "SØKNAD",
         behandlingOpprettet: LocalDateTime = LocalDateTime.now().minusDays(3)
     ): OppgaveId {
-        val oppgaveDto = OppgaveDto(
+        val oppgave = Oppgave(
             saksnummer = saksnummer,
             behandlingRef = behandlingRef,
             enhet = enhet,
@@ -1474,7 +1474,7 @@ class OppgaveRepositoryTest {
             årsakTilOpprettelse = årsakTilOpprettelse
         )
         return dataSource.transaction { connection ->
-            OppgaveRepository(connection).opprettOppgave(oppgaveDto)
+            OppgaveRepository(connection).opprettOppgave(oppgave)
         }
     }
 }

--- a/app/src/test/kotlin/no/nav/aap/oppgave/enhet/EnhetOgOversendelseTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/oppgave/enhet/EnhetOgOversendelseTest.kt
@@ -1,7 +1,7 @@
 package no.nav.aap.oppgave.enhet
 
 import no.nav.aap.behandlingsflyt.kontrakt.avklaringsbehov.Definisjon
-import no.nav.aap.oppgave.OppgaveDto
+import no.nav.aap.oppgave.Oppgave
 import no.nav.aap.oppgave.verdityper.Behandlingstype
 import no.nav.aap.oppgave.verdityper.Status
 import org.assertj.core.api.Assertions.assertThat
@@ -89,7 +89,7 @@ class EnhetOgOversendelseTest {
 
     private val tid = generateSequence(LocalDateTime.of(2022, 1, 1, 12, 0)) { it.plusDays(1) }.iterator()
 
-    fun oppgave(avklaringsbehov: Definisjon = Definisjon.AVKLAR_SYKDOM, enhet: String = "1234") = OppgaveDto(
+    fun oppgave(avklaringsbehov: Definisjon = Definisjon.AVKLAR_SYKDOM, enhet: String = "1234") = Oppgave(
         enhet = enhet,
         saksnummer = "SAK",
         behandlingRef = behandlingRef,
@@ -107,6 +107,6 @@ class EnhetOgOversendelseTest {
         behandlingstype = Behandlingstype.FØRSTEGANGSBEHANDLING
     )
 
-    private fun OppgaveDto.åpen() = this.copy(status = Status.OPPRETTET)
+    private fun Oppgave.åpen() = this.copy(status = Status.OPPRETTET)
 
 }

--- a/app/src/test/kotlin/no/nav/aap/oppgave/enhet/EnhetServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/oppgave/enhet/EnhetServiceTest.kt
@@ -7,10 +7,10 @@ import no.nav.aap.komponenter.dbtest.TestDataSource
 import no.nav.aap.komponenter.httpklient.httpclient.error.InternalServerErrorHttpResponsException
 import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.OidcToken
 import no.nav.aap.oppgave.AvklaringsbehovKode
-import no.nav.aap.oppgave.OppgaveDto
+import no.nav.aap.oppgave.Oppgave
 import no.nav.aap.oppgave.OppgaveId
 import no.nav.aap.oppgave.OppgaveRepository
-import no.nav.aap.oppgave.ReturInformasjon
+import no.nav.aap.oppgave.ReturInfo
 import no.nav.aap.oppgave.enhet.oppfølgingsenhet.OppfølgingsenhetService
 import no.nav.aap.oppgave.fakes.AzureTokenGen
 import no.nav.aap.oppgave.klienter.arena.IVeilarbarenaGateway
@@ -775,11 +775,11 @@ class EnhetServiceTest {
         påVentÅrsak: String? = null,
         venteBegrunnelse: String? = null,
         harUlesteDokumenter: Boolean = false,
-        returInformasjon: ReturInformasjon? = null,
+        returInformasjon: ReturInfo? = null,
         årsakTilOpprettelse: String? = "SØKNAD",
         behandlingOpprettet: LocalDateTime = LocalDateTime.now().minusDays(3)
     ): OppgaveId {
-        val oppgaveDto = OppgaveDto(
+        val oppgave = Oppgave(
             personIdent = personIdent,
             saksnummer = saksnummer,
             behandlingRef = behandlingRef,
@@ -801,7 +801,7 @@ class EnhetServiceTest {
             årsakTilOpprettelse = årsakTilOpprettelse
         )
         return dataSource.transaction { connection ->
-            OppgaveRepository(connection).opprettOppgave(oppgaveDto)
+            OppgaveRepository(connection).opprettOppgave(oppgave)
         }
     }
 

--- a/app/src/test/kotlin/no/nav/aap/oppgave/markering/MarkeringRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/oppgave/markering/MarkeringRepositoryTest.kt
@@ -3,7 +3,7 @@ package no.nav.aap.oppgave.markering
 import no.nav.aap.behandlingsflyt.kontrakt.sak.Saksnummer
 import no.nav.aap.komponenter.dbconnect.transaction
 import no.nav.aap.komponenter.dbtest.TestDataSource
-import no.nav.aap.oppgave.OppgaveDto
+import no.nav.aap.oppgave.Oppgave
 import no.nav.aap.oppgave.OppgaveRepository
 import no.nav.aap.oppgave.verdityper.Behandlingstype
 import no.nav.aap.oppgave.verdityper.MarkeringForBehandling
@@ -82,7 +82,7 @@ class MarkeringRepositoryTest {
 
             // Opprett oppgaver som knytter behandlingene til samme saksnummer
             oppgaveRepository.opprettOppgave(
-                OppgaveDto(
+                Oppgave(
                     saksnummer = saksnummer,
                     behandlingRef = behandlingRef1,
                     enhet = "0100",
@@ -96,7 +96,7 @@ class MarkeringRepositoryTest {
                 )
             )
             oppgaveRepository.opprettOppgave(
-                OppgaveDto(
+                Oppgave(
                     saksnummer = saksnummer,
                     behandlingRef = behandlingRef2,
                     enhet = "0100",

--- a/app/src/test/kotlin/no/nav/aap/oppgave/mottattdokument/MottattDokumentServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/oppgave/mottattdokument/MottattDokumentServiceTest.kt
@@ -3,7 +3,7 @@ package no.nav.aap.oppgave.mottattdokument
 import no.nav.aap.behandlingsflyt.kontrakt.hendelse.InnsendingType
 import no.nav.aap.komponenter.dbconnect.transaction
 import no.nav.aap.komponenter.dbtest.TestDataSource
-import no.nav.aap.oppgave.OppgaveDto
+import no.nav.aap.oppgave.Oppgave
 import no.nav.aap.oppgave.OppgaveRepository
 import no.nav.aap.oppgave.verdityper.Behandlingstype
 import org.assertj.core.api.Assertions.assertThat
@@ -58,7 +58,7 @@ class MottattDokumentServiceTest {
             referanse = UUID.randomUUID().toString(),
         )
 
-    private fun oppgave(behandlingRef: UUID) = OppgaveDto(
+    private fun oppgave(behandlingRef: UUID) = Oppgave(
         saksnummer = "1",
         behandlingRef = behandlingRef,
         behandlingOpprettet = LocalDateTime.now().minusDays(3),

--- a/app/src/test/kotlin/no/nav/aap/oppgave/oppdater/OppdaterOppgaveServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/oppgave/oppdater/OppdaterOppgaveServiceTest.kt
@@ -20,7 +20,7 @@ import no.nav.aap.komponenter.dbtest.TestDataSource
 import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.OidcToken
 import no.nav.aap.motor.FlytJobbRepository
 import no.nav.aap.oppgave.AvklaringsbehovKode
-import no.nav.aap.oppgave.OppgaveDto
+import no.nav.aap.oppgave.Oppgave
 import no.nav.aap.oppgave.OppgaveId
 import no.nav.aap.oppgave.OppgaveRepository
 import no.nav.aap.oppgave.ReturStatus
@@ -266,7 +266,7 @@ class OppdaterOppgaveServiceTest {
 
         val oppgaver = hentOppgaverForBehandling(behandlingsref)
         assertThat(oppgaver).hasSize(1).first()
-            .extracting(OppgaveDto::påVentÅrsak, OppgaveDto::påVentTil)
+            .extracting(Oppgave::påVentÅrsak, Oppgave::påVentTil)
             .containsExactly(
                 no.nav.aap.postmottak.kontrakt.hendelse.ÅrsakTilSettPåVent.VENTER_PÅ_OPPLYSNINGER.toString(),
                 venteFrist
@@ -291,7 +291,7 @@ class OppdaterOppgaveServiceTest {
         sendDokumentFlytStoppetHendelse(hendelse3)
         val oppgaver2 = hentOppgaverForBehandling(behandlingsref)
 
-        assertThat(oppgaver2).hasSize(1).first().extracting(OppgaveDto::påVentÅrsak, OppgaveDto::påVentTil)
+        assertThat(oppgaver2).hasSize(1).first().extracting(Oppgave::påVentÅrsak, Oppgave::påVentTil)
             .containsExactly(null, null)
     }
 
@@ -397,7 +397,7 @@ class OppdaterOppgaveServiceTest {
 
         val oppgaver = hentOppgaverForBehandling(behandlingsref)
 
-        assertThat(oppgaver).hasSize(1).first().extracting(OppgaveDto::påVentÅrsak, OppgaveDto::påVentTil)
+        assertThat(oppgaver).hasSize(1).first().extracting(Oppgave::påVentÅrsak, Oppgave::påVentTil)
             .containsExactly(ÅrsakTilSettPåVent.VENTER_PÅ_UTENLANDSK_VIDEREFORING_AVKLARING.toString(), venteFrist)
 
         // Ventebehovet avsluttes
@@ -420,7 +420,7 @@ class OppdaterOppgaveServiceTest {
 
         val oppgaver2 = hentOppgaverForBehandling(behandlingsref)
 
-        assertThat(oppgaver2).hasSize(1).first().extracting(OppgaveDto::påVentÅrsak, OppgaveDto::påVentTil)
+        assertThat(oppgaver2).hasSize(1).first().extracting(Oppgave::påVentÅrsak, Oppgave::påVentTil)
             .containsExactly(null, null)
     }
 
@@ -622,7 +622,7 @@ class OppdaterOppgaveServiceTest {
 
     private fun hentOppgaverForBehandling(
         behandlingsref: BehandlingReferanse
-    ): List<OppgaveDto> = dataSource.transaction { connection ->
+    ): List<Oppgave> = dataSource.transaction { connection ->
         OppgaveRepository(connection).hentOppgaver(
             referanse = behandlingsref.referanse,
         )
@@ -1609,7 +1609,7 @@ class OppdaterOppgaveServiceTest {
         veilederSykdom: String? = null,
         utløptVentefrist: LocalDate? = null
     ): Triple<OppgaveId, Saksnummer, BehandlingReferanse> {
-        val oppgaveDto = OppgaveDto(
+        val oppgave = Oppgave(
             saksnummer = saksnummer,
             behandlingRef = behandlingRef,
             enhet = enhet,
@@ -1625,12 +1625,12 @@ class OppdaterOppgaveServiceTest {
             utløptVentefrist = utløptVentefrist
         )
         val oppgaveId = dataSource.transaction { connection ->
-            OppgaveRepository(connection).opprettOppgave(oppgaveDto)
+            OppgaveRepository(connection).opprettOppgave(oppgave)
         }
         return Triple(oppgaveId, Saksnummer(saksnummer), BehandlingReferanse(behandlingRef))
     }
 
-    private fun hentOppgave(oppgaveId: OppgaveId): OppgaveDto {
+    private fun hentOppgave(oppgaveId: OppgaveId): Oppgave {
         return dataSource.transaction { connection ->
             OppgaveRepository(connection).hentOppgave(oppgaveId.id)
         }

--- a/app/src/test/kotlin/no/nav/aap/oppgave/prosessering/OppdaterOppgaveEnhetJobbTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/oppgave/prosessering/OppdaterOppgaveEnhetJobbTest.kt
@@ -10,7 +10,7 @@ import no.nav.aap.komponenter.dbtest.TestDataSource
 import no.nav.aap.motor.FlytJobbRepositoryImpl
 import no.nav.aap.motor.JobbInput
 import no.nav.aap.oppgave.AvklaringsbehovKode
-import no.nav.aap.oppgave.OppgaveDto
+import no.nav.aap.oppgave.Oppgave
 import no.nav.aap.oppgave.OppgaveId
 import no.nav.aap.oppgave.OppgaveRepository
 import no.nav.aap.oppgave.enhet.Enhet
@@ -146,7 +146,7 @@ class OppdaterOppgaveEnhetJobbTest {
         veilederArbeid: String? = null,
         veilederSykdom: String? = null,
     ): OppgaveId {
-        val oppgaveDto = OppgaveDto(
+        val oppgave = Oppgave(
             personIdent = personIdent,
             saksnummer = saksnummer,
             behandlingRef = behandlingRef,
@@ -162,11 +162,11 @@ class OppdaterOppgaveEnhetJobbTest {
             opprettetTidspunkt = LocalDateTime.now()
         )
         return dataSource.transaction { connection ->
-            OppgaveRepository(connection).opprettOppgave(oppgaveDto)
+            OppgaveRepository(connection).opprettOppgave(oppgave)
         }
     }
 
-    private fun hentOppgave(oppgaveId: OppgaveId): OppgaveDto {
+    private fun hentOppgave(oppgaveId: OppgaveId): Oppgave {
         return dataSource.transaction { connection ->
             OppgaveRepository(connection).hentOppgave(oppgaveId.id)
         }

--- a/app/src/test/kotlin/no/nav/aap/oppgave/tilbakekreving/TilbakekrevingRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/oppgave/tilbakekreving/TilbakekrevingRepositoryTest.kt
@@ -3,10 +3,10 @@ package no.nav.aap.oppgave.tilbakekreving
 import no.nav.aap.komponenter.dbconnect.transaction
 import no.nav.aap.komponenter.dbtest.TestDataSource
 import no.nav.aap.oppgave.AvklaringsbehovKode
-import no.nav.aap.oppgave.OppgaveDto
+import no.nav.aap.oppgave.Oppgave
 import no.nav.aap.oppgave.OppgaveId
 import no.nav.aap.oppgave.OppgaveRepository
-import no.nav.aap.oppgave.ReturInformasjon
+import no.nav.aap.oppgave.ReturInfo
 import no.nav.aap.oppgave.enhet.Enhet
 import no.nav.aap.oppgave.verdityper.Behandlingstype
 import no.nav.aap.oppgave.verdityper.Status
@@ -69,11 +69,11 @@ class TilbakekrevingRepositoryTest {
         påVentÅrsak: String? = null,
         venteBegrunnelse: String? = null,
         harUlesteDokumenter: Boolean = false,
-        returInformasjon: ReturInformasjon? = null,
+        returInformasjon: ReturInfo? = null,
         årsakTilOpprettelse: String? = "SØKNAD",
         behandlingOpprettet: LocalDateTime =LocalDateTime.now().minusDays(3)
     ): OppgaveId {
-        val oppgaveDto = OppgaveDto(
+        val oppgave = Oppgave(
             saksnummer = saksnummer,
             behandlingRef = behandlingRef,
             enhet = enhet,
@@ -94,7 +94,7 @@ class TilbakekrevingRepositoryTest {
             årsakTilOpprettelse = årsakTilOpprettelse
         )
         return dataSource.transaction { connection ->
-            OppgaveRepository(connection).opprettOppgave(oppgaveDto)
+            OppgaveRepository(connection).opprettOppgave(oppgave)
         }
     }
 


### PR DESCRIPTION
Lager Oppgave-klasse i app-modul som per nå er duplikat av OppgaveDto. OppgaveDto brukes nå bare i api-endepunkt. På sikt skal hvert endepunkt få sin egen DTO, frontend trenger aldri hele oppgave-objektet.