### PR TITLE
AAP-2194 Plukk uten tilgang skal svare med 403, ikke 401

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/oppgave/plukk/PlukkAPI.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/plukk/PlukkAPI.kt
@@ -52,7 +52,7 @@ fun NormalOpenAPIRoute.plukkOppgaveApi(
                 )
             )
         } else {
-            respondWithStatus(HttpStatusCode.Unauthorized)
+            respondWithStatus(HttpStatusCode.Forbidden)
         }
     }
 


### PR DESCRIPTION
Unngår at forsøk på plukk redirecter til ny login, skal isteden faktisk vise mangler tilgang-feilmelding