### PR TITLE
AAP-2235 Splitter filter fra filterDto + sletter ubrukte endepunkter

### DIFF
--- a/api-kontrakt/src/main/kotlin/no/nav/aap/oppgave/filter/FilterDto.kt
+++ b/api-kontrakt/src/main/kotlin/no/nav/aap/oppgave/filter/FilterDto.kt
@@ -4,43 +4,32 @@ import no.nav.aap.oppgave.verdityper.Behandlingstype
 import no.nav.aap.oppgave.verdityper.MarkeringForBehandling
 import java.time.LocalDateTime
 
-interface Filter {
-    val avklaringsbehovKoder: Set<String>
-    val behandlingstyper: Set<Behandlingstype>
-    val enheter: Set<String>
-    val veileder: String?
-    val inkluderteMarkeringer: Set<MarkeringForBehandling>
-    val ekskluderteMarkeringer: Set<MarkeringForBehandling>
-}
-
-enum class FilterType {
-    GENERELL,
-    ALLE_OPPGAVER,
-    KVALITETSSIKRING,
-}
-
 data class FilterDto(
-    val id: Long? = null,
+    val id: Long,
     val navn: String,
     val beskrivelse: String,
-    override val avklaringsbehovKoder: Set<String> = emptySet(),
-    override val behandlingstyper: Set<Behandlingstype> = emptySet(),
-    override val enheter: Set<String> = emptySet(),
-    override val veileder: String? = null,
-    override val inkluderteMarkeringer: Set<MarkeringForBehandling> = emptySet(),
-    override val ekskluderteMarkeringer: Set<MarkeringForBehandling> = emptySet(),
+    val avklaringsbehovKoder: Set<String> = emptySet(),
+    val behandlingstyper: Set<Behandlingstype> = emptySet(),
+    val enheter: Set<String> = emptySet(),
+    val veileder: String? = null,
+    val inkluderteMarkeringer: Set<MarkeringForBehandling> = emptySet(),
+    val ekskluderteMarkeringer: Set<MarkeringForBehandling> = emptySet(),
     val opprettetAv: String,
     val opprettetTidspunkt: LocalDateTime,
     val endretAv: String? = null,
     val endretTidspunkt: LocalDateTime? = null,
-    val type: FilterType,
-): Filter
+    val type: FilterTypeDto,
+)
 
-data class TransientFilterDto(
-    override val avklaringsbehovKoder: Set<String> = emptySet(),
-    override val behandlingstyper: Set<Behandlingstype> = emptySet(),
-    override val enheter: Set<String> = emptySet(),
-    override val veileder: String? = null,
-    override val inkluderteMarkeringer: Set<MarkeringForBehandling> = emptySet(),
-    override val ekskluderteMarkeringer: Set<MarkeringForBehandling> = emptySet(),
-): Filter
+data class FilterResponse(
+    val id: Long,
+    val navn: String,
+    val beskrivelse: String,
+    val type: FilterTypeDto,
+)
+
+enum class FilterTypeDto {
+    GENERELL,
+    ALLE_OPPGAVER,
+    KVALITETSSIKRING,
+}

--- a/app/src/main/kotlin/no/nav/aap/oppgave/drift/DriftApi.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/drift/DriftApi.kt
@@ -16,12 +16,13 @@ import no.nav.aap.oppgave.Oppgave
 import no.nav.aap.oppgave.OppgaveRepository
 import no.nav.aap.oppgave.enhet.EnhetService
 import no.nav.aap.oppgave.filter.EnhetFilter
-import no.nav.aap.oppgave.filter.FilterDto
+import no.nav.aap.oppgave.filter.Filter
 import no.nav.aap.oppgave.filter.FilterRepository
 import no.nav.aap.oppgave.filter.Filtermodus
 import no.nav.aap.oppgave.filter.MarkeringFilter
 import no.nav.aap.oppgave.filter.OppdaterFilter
 import no.nav.aap.oppgave.filter.OpprettFilter
+import no.nav.aap.oppgave.filter.tilDto
 import no.nav.aap.oppgave.historikk.OppgaveHistorikk
 import no.nav.aap.oppgave.historikk.OppgaveHistorikkRepository
 import no.nav.aap.oppgave.klienter.norg.INorgGateway
@@ -111,7 +112,7 @@ fun NormalOpenAPIRoute.driftApi(
                             OpprettFilter(
                                 navn = request.navn,
                                 beskrivelse = request.beskrivelse,
-                                avklaringsbehovtyper = request.avklaringsbehovKoder,
+                                avklaringsbehovKoder = request.avklaringsbehovKoder,
                                 behandlingstyper = request.behandlingstyper,
                                 enhetFilter = enhetFilter,
                                 markeringer = markeringFilter,
@@ -161,11 +162,11 @@ fun NormalOpenAPIRoute.driftApi(
     }
 }
 
-private fun FilterDto.tilDriftResponse(enhetPerFilter: Map<Long, List<EnhetFilter>>) = FilterDriftResponse(
-    id = id!!,
+private fun Filter.tilDriftResponse(enhetPerFilter: Map<Long, List<EnhetFilter>>) = FilterDriftResponse(
+    id = id,
     navn = navn,
     beskrivelse = beskrivelse,
-    type = type,
+    type = type.tilDto(),
     avklaringsbehov = avklaringsbehovKoder.map { AvklaringsbehovDto(it, utledAvklaringsbehovnavn(it)) }.toSet(),
     behandlingstyper = behandlingstyper,
     inkluderteEnheter = (enhetPerFilter[id] ?: emptyList())

--- a/app/src/main/kotlin/no/nav/aap/oppgave/drift/DriftApi.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/drift/DriftApi.kt
@@ -99,7 +99,7 @@ fun NormalOpenAPIRoute.driftApi(
                                 id = request.id,
                                 navn = request.navn,
                                 beskrivelse = request.beskrivelse,
-                                avklaringsbehovtyper = request.avklaringsbehovKoder,
+                                avklaringsbehovKoder = request.avklaringsbehovKoder,
                                 behandlingstyper = request.behandlingstyper,
                                 enhetFilter = enhetFilter,
                                 markeringer = markeringFilter,

--- a/app/src/main/kotlin/no/nav/aap/oppgave/drift/DriftDto.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/drift/DriftDto.kt
@@ -2,7 +2,7 @@ package no.nav.aap.oppgave.drift
 
 import java.time.LocalDateTime
 import java.util.UUID
-import no.nav.aap.oppgave.filter.FilterType
+import no.nav.aap.oppgave.filter.FilterTypeDto
 import no.nav.aap.oppgave.filter.Filtermodus
 import no.nav.aap.oppgave.verdityper.Behandlingstype
 import no.nav.aap.oppgave.verdityper.MarkeringForBehandling
@@ -33,7 +33,7 @@ data class FilterDriftResponse(
     val id: Long,
     val navn: String,
     val beskrivelse: String,
-    val type: FilterType,
+    val type: FilterTypeDto,
     val avklaringsbehov: Set<AvklaringsbehovDto>,
     val behandlingstyper: Set<Behandlingstype>,
     val inkluderteEnheter: List<String>,
@@ -50,7 +50,7 @@ data class FilterDriftRequest(
     val id: Long? = null,
     val navn: String,
     val beskrivelse: String,
-    val type: FilterType = FilterType.GENERELL,
+    val type: FilterTypeDto = FilterTypeDto.GENERELL,
     val avklaringsbehovKoder: Set<String> = emptySet(),
     val behandlingstyper: Set<Behandlingstype> = emptySet(),
     val enheter: List<EnhetDriftRequest> = emptyList(),

--- a/app/src/main/kotlin/no/nav/aap/oppgave/filter/Filter.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/filter/Filter.kt
@@ -1,0 +1,99 @@
+package no.nav.aap.oppgave.filter
+
+import no.nav.aap.oppgave.verdityper.Behandlingstype
+import no.nav.aap.oppgave.verdityper.MarkeringForBehandling
+import java.time.LocalDateTime
+
+
+enum class FilterType {
+    GENERELL,
+    ALLE_OPPGAVER,
+    KVALITETSSIKRING,
+}
+
+data class Filter(
+    val id: Long,
+    val navn: String,
+    val beskrivelse: String,
+    val avklaringsbehovKoder: Set<String> = emptySet(),
+    val behandlingstyper: Set<Behandlingstype> = emptySet(),
+    val enheter: Set<String> = emptySet(),
+    val veileder: String? = null,
+    val inkluderteMarkeringer: Set<MarkeringForBehandling> = emptySet(),
+    val ekskluderteMarkeringer: Set<MarkeringForBehandling> = emptySet(),
+    val opprettetAv: String,
+    val opprettetTidspunkt: LocalDateTime,
+    val endretAv: String? = null,
+    val endretTidspunkt: LocalDateTime? = null,
+    val type: FilterType,
+) {
+    fun tilDtoV2(): FilterResponse {
+        return FilterResponse(
+            id = id,
+            navn = navn,
+            beskrivelse = beskrivelse,
+            type = type.tilDto()
+        )
+    }
+
+    fun tilDto(): FilterDto {
+        return FilterDto(
+            id = id,
+            navn = navn,
+            beskrivelse = beskrivelse,
+            avklaringsbehovKoder = avklaringsbehovKoder,
+            behandlingstyper = behandlingstyper,
+            enheter = enheter,
+            veileder = veileder,
+            inkluderteMarkeringer = inkluderteMarkeringer,
+            ekskluderteMarkeringer = ekskluderteMarkeringer,
+            opprettetAv = opprettetAv,
+            opprettetTidspunkt = opprettetTidspunkt,
+            endretAv = endretAv,
+            endretTidspunkt = endretTidspunkt,
+            type = type.tilDto()
+        )
+    }
+}
+
+data class OpprettFilter(
+    val navn: String,
+    val beskrivelse: String,
+    val avklaringsbehovKoder: Set<String> = emptySet(),
+    val behandlingstyper: Set<Behandlingstype> = emptySet(),
+    val opprettetAv: String,
+    val opprettetTidspunkt: LocalDateTime,
+    val enhetFilter: List<EnhetFilter>? = null,
+    val markeringer: List<MarkeringFilter> = emptyList(),
+    val type: FilterTypeDto = FilterTypeDto.GENERELL,
+)
+
+data class EnhetFilter(
+    val enhetNr: String,
+    val filtermodus: Filtermodus
+)
+
+data class MarkeringFilter(
+    val markeringType: MarkeringForBehandling,
+    val filtermodus: Filtermodus
+)
+
+data class OppdaterFilter(
+    val id: Long,
+    val navn: String,
+    val beskrivelse: String,
+    val avklaringsbehovtyper: Set<String> = emptySet(),
+    val behandlingstyper: Set<Behandlingstype> = emptySet(),
+    val markeringer: List<MarkeringFilter> = emptyList(),
+    val enhetFilter: List<EnhetFilter>? = null,
+    val endretAv: String? = null,
+    val endretTidspunkt: LocalDateTime? = null,
+)
+
+fun FilterType.tilDto(): FilterTypeDto {
+    return when (this) {
+        FilterType.GENERELL -> FilterTypeDto.GENERELL
+        FilterType.ALLE_OPPGAVER -> FilterTypeDto.ALLE_OPPGAVER
+        FilterType.KVALITETSSIKRING -> FilterTypeDto.KVALITETSSIKRING
+    }
+}

--- a/app/src/main/kotlin/no/nav/aap/oppgave/filter/Filter.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/filter/Filter.kt
@@ -82,7 +82,7 @@ data class OppdaterFilter(
     val id: Long,
     val navn: String,
     val beskrivelse: String,
-    val avklaringsbehovtyper: Set<String> = emptySet(),
+    val avklaringsbehovKoder: Set<String> = emptySet(),
     val behandlingstyper: Set<Behandlingstype> = emptySet(),
     val markeringer: List<MarkeringFilter> = emptyList(),
     val enhetFilter: List<EnhetFilter>? = null,

--- a/app/src/main/kotlin/no/nav/aap/oppgave/filter/Filter.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/filter/Filter.kt
@@ -27,7 +27,7 @@ data class Filter(
     val endretTidspunkt: LocalDateTime? = null,
     val type: FilterType,
 ) {
-    fun tilDtoV2(): FilterResponse {
+    fun tilResponse(): FilterResponse {
         return FilterResponse(
             id = id,
             navn = navn,

--- a/app/src/main/kotlin/no/nav/aap/oppgave/filter/FilterAPI.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/filter/FilterAPI.kt
@@ -2,70 +2,28 @@ package no.nav.aap.oppgave.filter
 
 import com.papsign.ktor.openapigen.route.path.normal.NormalOpenAPIRoute
 import com.papsign.ktor.openapigen.route.path.normal.get
-import com.papsign.ktor.openapigen.route.path.normal.post
 import com.papsign.ktor.openapigen.route.response.respond
 import com.papsign.ktor.openapigen.route.route
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
 import no.nav.aap.komponenter.dbconnect.transaction
 import no.nav.aap.oppgave.metrikker.httpCallCounter
-import no.nav.aap.oppgave.server.authenticate.ident
-import java.time.LocalDateTime
 import javax.sql.DataSource
 
-fun NormalOpenAPIRoute.hentFilterApi(dataSource: DataSource, prometheus: PrometheusMeterRegistry) =
+fun NormalOpenAPIRoute.hentFilterApi(dataSource: DataSource, prometheus: PrometheusMeterRegistry) {
 
     route("/filter").get<FilterRequestDto, List<FilterDto>> { req ->
         prometheus.httpCallCounter("/filter").increment()
         val filterListe = dataSource.transaction(readOnly = true) { connection ->
             FilterRepository(connection).hentForEnheter(req.enheter)
-        }
+        }.map { it.tilDto() }
         respond(filterListe)
     }
 
-fun NormalOpenAPIRoute.opprettEllerOppdaterFilterApi(dataSource: DataSource, prometheus: PrometheusMeterRegistry) =
-
-    // TODO: Denne bør ha en egen DTO for å skille mellom opprett og hent
-    route("/filter").post<Unit, FilterDto, FilterDto> { _, request ->
-        prometheus.httpCallCounter("/filter").increment()
-
-        val filterId = dataSource.transaction { connection ->
-            val filterRepo = FilterRepository(connection)
-
-            if (request.id != null) {
-                filterRepo.oppdater(OppdaterFilter(
-                    id = request.id!!,
-                    navn = request.navn,
-                    beskrivelse = request.beskrivelse,
-                    avklaringsbehovtyper = request.avklaringsbehovKoder,
-                    behandlingstyper = request.behandlingstyper,
-                    markeringer = request.inkluderteMarkeringer.map { MarkeringFilter(it, Filtermodus.INKLUDER) } +
-                                  request.ekskluderteMarkeringer.map { MarkeringFilter(it, Filtermodus.EKSKLUDER) },
-                    endretAv = ident(),
-                    endretTidspunkt = LocalDateTime.now(),
-                ))
-            } else {
-                filterRepo.opprett(OpprettFilter(
-                    navn = request.navn,
-                    beskrivelse = request.beskrivelse,
-                    avklaringsbehovtyper = request.avklaringsbehovKoder,
-                    behandlingstyper = request.behandlingstyper,
-                    opprettetAv = ident(),
-                    opprettetTidspunkt = LocalDateTime.now(),
-                    enhetFilter = request.enheter?.map { EnhetFilter(it, Filtermodus.INKLUDER) },
-                    markeringer = request.inkluderteMarkeringer.map { MarkeringFilter(it, Filtermodus.INKLUDER) } +
-                                  request.ekskluderteMarkeringer.map { MarkeringFilter(it, Filtermodus.EKSKLUDER) },
-                ))
-            }
-        }
-        respond(request.copy(id = filterId))
+    route("/filter/v2").get<FilterRequestDto, List<FilterResponse>> { req ->
+        prometheus.httpCallCounter("/filter/v2").increment()
+        val filterListe = dataSource.transaction(readOnly = true) { connection ->
+            FilterRepository(connection).hentForEnheter(req.enheter)
+        }.map { it.tilDtoV2() }
+        respond(filterListe)
     }
-
-fun NormalOpenAPIRoute.slettFilterApi(dataSource: DataSource, prometheus: PrometheusMeterRegistry) =
-
-    route("/filter/{filterId}/slett").post<Unit, Unit, FilterId> { _, req ->
-        prometheus.httpCallCounter("/filter/{filterId}/slett").increment()
-        dataSource.transaction { connection ->
-            FilterRepository(connection).slettFilter(req.filterId)
-        }
-        respond(Unit)
-    }
+}

--- a/app/src/main/kotlin/no/nav/aap/oppgave/filter/FilterAPI.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/filter/FilterAPI.kt
@@ -23,7 +23,7 @@ fun NormalOpenAPIRoute.hentFilterApi(dataSource: DataSource, prometheus: Prometh
         prometheus.httpCallCounter("/filter/v2").increment()
         val filterListe = dataSource.transaction(readOnly = true) { connection ->
             FilterRepository(connection).hentForEnheter(req.enheter)
-        }.map { it.tilDtoV2() }
+        }.map { it.tilResponse() }
         respond(filterListe)
     }
 }

--- a/app/src/main/kotlin/no/nav/aap/oppgave/filter/FilterRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/filter/FilterRepository.kt
@@ -2,60 +2,24 @@ package no.nav.aap.oppgave.filter
 
 import no.nav.aap.komponenter.dbconnect.DBConnection
 import no.nav.aap.oppgave.verdityper.Behandlingstype
-import no.nav.aap.oppgave.verdityper.MarkeringForBehandling
-import java.time.LocalDateTime
-
-data class OpprettFilter(
-    val navn: String,
-    val beskrivelse: String,
-    val avklaringsbehovtyper: Set<String> = emptySet(),
-    val behandlingstyper: Set<Behandlingstype> = emptySet(),
-    val opprettetAv: String,
-    val opprettetTidspunkt: LocalDateTime,
-    val enhetFilter: List<EnhetFilter>? = null,
-    val markeringer: List<MarkeringFilter> = emptyList(),
-    val type: FilterType = FilterType.GENERELL,
-)
-
-data class EnhetFilter(
-    val enhetNr: String,
-    val filtermodus: Filtermodus
-)
-
-data class MarkeringFilter(
-    val markeringType: MarkeringForBehandling,
-    val filtermodus: Filtermodus
-)
-
-data class OppdaterFilter(
-    val id: Long,
-    val navn: String,
-    val beskrivelse: String,
-    val avklaringsbehovtyper: Set<String> = emptySet(),
-    val behandlingstyper: Set<Behandlingstype> = emptySet(),
-    val markeringer: List<MarkeringFilter> = emptyList(),
-    val enhetFilter: List<EnhetFilter>? = null,
-    val endretAv: String? = null,
-    val endretTidspunkt: LocalDateTime? = null,
-)
 
 class FilterRepository(private val connection: DBConnection) {
 
-    fun hentAlle(): List<FilterDto> {
+    fun hentAlle(): List<Filter> {
         return hentFilter(null)
     }
 
-    fun hent(filterId: Long): FilterDto? {
+    fun hent(filterId: Long): Filter? {
         return hentFilter(filterId).firstOrNull()
     }
 
-    fun hentForEnheter(enheter: List<String>?): List<FilterDto> {
+    fun hentForEnheter(enheter: List<String>?): List<Filter> {
         return hentFilterForEnheter(enheter)
     }
 
     fun opprett(filter: OpprettFilter): Long {
         val filterId = opprettFilter(filter)
-        opprettFilterAvklaringsbehovtyper(filterId, filter.avklaringsbehovtyper)
+        opprettFilterAvklaringsbehovtyper(filterId, filter.avklaringsbehovKoder)
         opprettFilterBehandlingstyper(filterId, filter.behandlingstyper)
         opprettFilterEnheter(filterId, filter.enhetFilter)
         opprettFilterMarkeringer(filterId, filter.markeringer)
@@ -225,7 +189,7 @@ class FilterRepository(private val connection: DBConnection) {
     }
 
 
-    private fun hentFilterForEnheter(enheter: List<String>?): List<FilterDto> {
+    private fun hentFilterForEnheter(enheter: List<String>?): List<Filter> {
         val enhetsfilter = if (!enheter.isNullOrEmpty())
             """AND ID IN (SELECT FILTER_ID FROM FILTER_ENHET WHERE FILTER_MODUS = 'INKLUDER' AND (ENHET = 'ALLE' OR ENHET = ANY(?::text[])))
                AND ID NOT IN (SELECT FILTER_ID FROM FILTER_ENHET WHERE FILTER_MODUS = 'EKSKLUDER' AND (ENHET = 'ALLE' OR ENHET = ANY(?::text[])))""".trimIndent()
@@ -249,7 +213,7 @@ class FilterRepository(private val connection: DBConnection) {
                 }
             }
             setRowMapper { row ->
-                FilterDto(
+                Filter(
                     id = row.getLong("ID"),
                     navn = row.getString("NAVN"),
                     beskrivelse = row.getString("BESKRIVELSE"),
@@ -283,7 +247,7 @@ class FilterRepository(private val connection: DBConnection) {
     }
 
 
-    private fun hentFilter(filterId: Long?): List<FilterDto> {
+    private fun hentFilter(filterId: Long?): List<Filter> {
         val filterIdClause = if (filterId != null) " AND ID = ?" else ""
         val query = """
             SELECT 
@@ -301,7 +265,7 @@ class FilterRepository(private val connection: DBConnection) {
                 }
             }
             setRowMapper { row ->
-                FilterDto(
+                Filter(
                     id = row.getLong("ID"),
                     navn = row.getString("NAVN"),
                     beskrivelse = row.getString("BESKRIVELSE"),

--- a/app/src/main/kotlin/no/nav/aap/oppgave/filter/FilterRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/filter/FilterRepository.kt
@@ -31,7 +31,7 @@ class FilterRepository(private val connection: DBConnection) {
         oppdaterFilter(filter)
         slettFilterParametre(filter.id)
         slettFilterEnheter(filter.id)
-        opprettFilterAvklaringsbehovtyper(filter.id, filter.avklaringsbehovtyper)
+        opprettFilterAvklaringsbehovtyper(filter.id, filter.avklaringsbehovKoder)
         opprettFilterBehandlingstyper(filter.id, filter.behandlingstyper)
         opprettFilterEnheter(filter.id, filter.enhetFilter)
         opprettFilterMarkeringer(filter.id, filter.markeringer)

--- a/app/src/main/kotlin/no/nav/aap/oppgave/oppgaveliste/OppgavelisteService.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/oppgaveliste/OppgavelisteService.kt
@@ -10,7 +10,7 @@ import no.nav.aap.oppgave.OppgaveRepository
 import no.nav.aap.oppgave.OppgaveRepository.FinnOppgaverDto
 import no.nav.aap.oppgave.enhet.EnhetService
 import no.nav.aap.oppgave.enhet.OppgaveEnhetDto
-import no.nav.aap.oppgave.filter.FilterDto
+import no.nav.aap.oppgave.filter.Filter
 import no.nav.aap.oppgave.klienter.norg.INorgGateway
 import no.nav.aap.oppgave.liste.OppgaveSorteringFelt
 import no.nav.aap.oppgave.liste.OppgaveSorteringFelt.TILBAKEKREVINGS_BELOP
@@ -72,7 +72,7 @@ class OppgavelisteService(
         enheter: Set<String>,
         paging: Paging,
         kunLedigeOppgaver: Boolean,
-        filter: FilterDto,
+        filter: Filter,
         veilederIdent: String?,
         token: OidcToken,
         ident: String,
@@ -166,9 +166,9 @@ class OppgavelisteService(
     }
 
     private fun validerOgKombinerFiltre(
-        filter: FilterDto,
+        filter: Filter,
         utvidetFilter: UtvidetOppgavelisteFilter?
-    ): FilterDto? {
+    ): Filter? {
         if (utvidetFilter == null) return filter
         val avklaringsbehovKoder =
             utledAvklaringsbehovKoderForUtvidetFilter(filter.avklaringsbehovKoder, utvidetFilter.avklaringsbehovKoder)

--- a/app/src/main/kotlin/no/nav/aap/oppgave/server/App.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/server/App.kt
@@ -39,8 +39,6 @@ import no.nav.aap.oppgave.enhet.nayEnhetForPerson
 import no.nav.aap.oppgave.enhet.oppfølgingsenhet.OppfølgingsenhetService
 import no.nav.aap.oppgave.enhet.synkroniserEnhetPåOppgaveApi
 import no.nav.aap.oppgave.filter.hentFilterApi
-import no.nav.aap.oppgave.filter.opprettEllerOppdaterFilterApi
-import no.nav.aap.oppgave.filter.slettFilterApi
 import no.nav.aap.oppgave.klienter.arena.VeilarbarenaGateway
 import no.nav.aap.oppgave.klienter.msgraph.MsGraphGateway
 import no.nav.aap.oppgave.klienter.nom.ansattinfo.NomApiGateway
@@ -156,8 +154,6 @@ internal fun Application.server(dbConfig: DbConfig, prometheus: PrometheusMeterR
                 sistEndretApi(dataSource)
                 // Filter
                 hentFilterApi(dataSource, prometheus)
-                opprettEllerOppdaterFilterApi(dataSource, prometheus)
-                slettFilterApi(dataSource, prometheus)
                 // Produksjonsstyring
                 hentAntallOppgaver(dataSource, prometheus)
                 // Enheter

--- a/app/src/test/kotlin/no/nav/aap/oppgave/FilterApiTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/oppgave/FilterApiTest.kt
@@ -4,28 +4,23 @@ import io.ktor.server.engine.EmbeddedServer
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
 import io.ktor.server.netty.NettyApplicationEngine
-import java.net.URI
-import java.time.Duration
-import java.time.LocalDateTime
-import java.time.temporal.ChronoUnit
-import no.nav.aap.behandlingsflyt.kontrakt.avklaringsbehov.Definisjon
 import no.nav.aap.komponenter.dbconnect.transaction
 import no.nav.aap.komponenter.httpklient.httpclient.ClientConfig
 import no.nav.aap.komponenter.httpklient.httpclient.RestClient
 import no.nav.aap.komponenter.httpklient.httpclient.get
-import no.nav.aap.komponenter.httpklient.httpclient.post
 import no.nav.aap.komponenter.httpklient.httpclient.request.GetRequest
-import no.nav.aap.komponenter.httpklient.httpclient.request.PostRequest
 import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.azurecc.AzureOBOTokenProvider
 import no.nav.aap.oppgave.fakes.Fakes
-import no.nav.aap.oppgave.filter.FilterDto
-import no.nav.aap.oppgave.filter.FilterId
-import no.nav.aap.oppgave.filter.FilterType
+import no.nav.aap.oppgave.filter.EnhetFilter
+import no.nav.aap.oppgave.filter.FilterResponse
+import no.nav.aap.oppgave.filter.FilterRepository
+import no.nav.aap.oppgave.filter.FilterTypeDto
+import no.nav.aap.oppgave.filter.Filtermodus
+import no.nav.aap.oppgave.filter.OpprettFilter
 import no.nav.aap.oppgave.metrikker.prometheus
 import no.nav.aap.oppgave.server.DbConfig
 import no.nav.aap.oppgave.server.initDatasource
 import no.nav.aap.oppgave.server.server
-import no.nav.aap.oppgave.verdityper.Behandlingstype
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
@@ -36,6 +31,10 @@ import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy
 import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
+import java.net.URI
+import java.time.Duration
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
 
 @ExtendWith(Fakes::class)
 @Testcontainers
@@ -106,145 +105,63 @@ class FilterApiTest {
     }
 
     @Test
-    fun `Endre filter`() {
-        // Opprett filter
-        opprettEllerOppdaterFilter(
-            FilterDto(
-                navn = "Avklare sykdom i førstegangsbehandling filter",
-                beskrivelse = "Avklare sykdom i førstegangsbehandling filter",
-                behandlingstyper = setOf(Behandlingstype.FØRSTEGANGSBEHANDLING),
-                avklaringsbehovKoder = setOf(Definisjon.AVKLAR_SYKDOM.kode.name),
-                opprettetAv = "test",
-                opprettetTidspunkt = LocalDateTime.now(),
-                type = FilterType.GENERELL,
-            )
-        )
-
-        // Sjekk lagret filter
-        val alleFilter = hentAlleFilter()
-        assertThat(alleFilter).hasSize(1)
-        val hentetFilter = alleFilter.first()
-        assertThat(hentetFilter.behandlingstyper).isEqualTo(setOf(Behandlingstype.FØRSTEGANGSBEHANDLING))
-        assertThat(hentetFilter.avklaringsbehovKoder).isEqualTo(setOf(Definisjon.AVKLAR_SYKDOM.kode.name))
-
-        // Oppdater filter
-        opprettEllerOppdaterFilter(
-            hentetFilter.copy(
-                navn = "Forslå vedtak i revurdering filter",
-                behandlingstyper = setOf(Behandlingstype.REVURDERING),
-                avklaringsbehovKoder = setOf(Definisjon.FORESLÅ_VEDTAK.kode.name),
-                endretAv = "test",
-                endretTidspunkt = LocalDateTime.now(),
-            )
-        )
-
-        // Sjekk oppdatert filter
-        val alleFilterEtterOppdatering = hentAlleFilter()
-        assertThat(alleFilterEtterOppdatering).hasSize(1)
-        val hentetFilterEtterOppdatering = alleFilterEtterOppdatering.first()
-        assertThat(hentetFilterEtterOppdatering.navn).isEqualTo("Forslå vedtak i revurdering filter")
-        assertThat(hentetFilterEtterOppdatering.behandlingstyper).isEqualTo(setOf(Behandlingstype.REVURDERING))
-        assertThat(hentetFilterEtterOppdatering.avklaringsbehovKoder).isEqualTo(setOf(Definisjon.FORESLÅ_VEDTAK.kode.name))
-    }
-
-    @Test
-    fun `Slette filter`() {
-        opprettEllerOppdaterFilter(
-            FilterDto(
-                navn = "Simpelt filter",
-                beskrivelse = "Simpelt filter",
-                opprettetAv = "test",
-                opprettetTidspunkt = LocalDateTime.now(),
-                type = FilterType.GENERELL,
-            )
-        )
-
-        val alleFilter = hentAlleFilter()
-        assertThat(alleFilter).hasSize(1)
-
-        val hentetFilter = alleFilter.first()
-        slettFilter(FilterId(hentetFilter.id!!))
-
-        val alleFilterEtterSletting = hentAlleFilter()
-        assertThat(alleFilterEtterSletting).hasSize(0)
-    }
-
-    @Test
     fun `Hente filter`() {
-        opprettEllerOppdaterFilter(
-            FilterDto(
-                navn = "Simpelt filter",
-                beskrivelse = "Et enkelt filter for alle oppgave",
-                opprettetAv = "test",
-                opprettetTidspunkt = LocalDateTime.now(),
-                type = FilterType.GENERELL,
-            )
-        )
-
+        opprettFiltre()
         val alleFilter = hentAlleFilter()
-
-        assertThat(alleFilter).hasSize(1)
+        assertThat(alleFilter).hasSize(2)
     }
 
     @Test
     fun `Hente filter for enhet`() {
-        val filter1 = FilterDto(
-            navn = "Simpelt filter",
-            beskrivelse = "Et enkelt filter for alle oppgave",
-            enheter = setOf("1234"),
-            opprettetAv = "test",
-            opprettetTidspunkt = LocalDateTime.now(),
-            type = FilterType.GENERELL,
-        )
-        val id1 = opprettEllerOppdaterFilter(
-            filter1
-        )!!.id
+        opprettFiltre()
+        val filtre = hentFilterForEnhet(listOf("1234"))
 
-        val id2 = opprettEllerOppdaterFilter(
-            FilterDto(
-                navn = "Simpelt filter 2",
-                beskrivelse = "Et enkelt filter for alle oppgave",
-                enheter = setOf("6789"),
-                opprettetAv = "test",
-                opprettetTidspunkt = LocalDateTime.now(),
-                type = FilterType.GENERELL,
+        assertThat(filtre.size).isEqualTo(2)
+        assertThat(filtre.map { it.navn }).containsExactlyInAnyOrder("Simpelt filter", "Filter med enhet")
+
+        val filtre2 = hentFilterForEnhet(listOf("1235"))
+
+        assertThat(filtre2.size).isEqualTo(1)
+        assertThat(filtre2.first().navn).isEqualTo("Simpelt filter")
+    }
+
+    private fun hentFilterForEnhet(enheter: List<String>): List<FilterResponse> {
+        return oboClient().get<List<FilterResponse>>(
+            URI.create("http://localhost:$port/filter/v2?enheter=${enheter.joinToString("&enheter=")}"),
+            GetRequest(currentToken = getOboToken())
+        )!!
+    }
+
+
+    private fun hentAlleFilter(): List<FilterResponse> {
+        return oboClient().get<List<FilterResponse>>(
+            URI.create("http://localhost:$port/filter/v2"),
+            GetRequest(currentToken = getOboToken())
+        )!!
+    }
+
+    private fun opprettFiltre() {
+        initDatasource(dbConfig(), prometheus).transaction { connection ->
+            val filterRepo = FilterRepository(connection)
+            filterRepo.opprett(
+                OpprettFilter(
+                    navn = "Simpelt filter",
+                    beskrivelse = "Et enkelt filter for alle oppgave",
+                    opprettetAv = "test",
+                    opprettetTidspunkt = LocalDateTime.now(),
+                    type = FilterTypeDto.GENERELL,
+                )
             )
-        )!!.id
-
-        val filtre = hentFilter(listOf("1234", "1235"))
-
-        assertThat(filtre.size).isEqualTo(1)
-        assertThat(filtre.find { it.id == id1 }!!.navn).isEqualTo("Simpelt filter")
-        assertThat(filtre.find { it.id == id2 }).isNull()
+            filterRepo.opprett(
+                OpprettFilter(
+                    navn = "Filter med enhet",
+                    beskrivelse = "Et filter for en spesifikk enhet",
+                    opprettetAv = "test",
+                    opprettetTidspunkt = LocalDateTime.now(),
+                    enhetFilter = listOf(EnhetFilter(enhetNr = "1234", filtermodus = Filtermodus.INKLUDER)),
+                    type = FilterTypeDto.GENERELL,
+                )
+            )
+        }
     }
-
-    private fun hentFilter(enheter: List<String>): List<FilterDto> {
-        return oboClient().get<List<FilterDto>>(
-            URI.create("http://localhost:$port/filter?enheter=${enheter.joinToString("&enheter=")}"),
-            GetRequest(currentToken = getOboToken())
-        )!!
-    }
-
-
-    private fun slettFilter(filterId: FilterId): Unit? {
-        return oboClient().post(
-            URI.create("http://localhost:$port/filter/${filterId.filterId}/slett"),
-            PostRequest(body = filterId, currentToken = getOboToken())
-        )
-    }
-
-    private fun opprettEllerOppdaterFilter(filter: FilterDto): FilterDto? {
-        return oboClient().post(
-            URI.create("http://localhost:$port/filter"),
-            PostRequest(body = filter, currentToken = getOboToken())
-        )
-    }
-
-    private fun hentAlleFilter(): List<FilterDto> {
-        return oboClient().get<List<FilterDto>>(
-            URI.create("http://localhost:$port/filter"),
-            GetRequest(currentToken = getOboToken())
-        )!!
-    }
-
 }

--- a/app/src/test/kotlin/no/nav/aap/oppgave/FilterApiTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/oppgave/FilterApiTest.kt
@@ -12,8 +12,8 @@ import no.nav.aap.komponenter.httpklient.httpclient.request.GetRequest
 import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.azurecc.AzureOBOTokenProvider
 import no.nav.aap.oppgave.fakes.Fakes
 import no.nav.aap.oppgave.filter.EnhetFilter
-import no.nav.aap.oppgave.filter.FilterResponse
 import no.nav.aap.oppgave.filter.FilterRepository
+import no.nav.aap.oppgave.filter.FilterResponse
 import no.nav.aap.oppgave.filter.FilterTypeDto
 import no.nav.aap.oppgave.filter.Filtermodus
 import no.nav.aap.oppgave.filter.OpprettFilter
@@ -35,6 +35,7 @@ import java.net.URI
 import java.time.Duration
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
+import javax.sql.DataSource
 
 @ExtendWith(Fakes::class)
 @Testcontainers
@@ -49,6 +50,11 @@ class FilterApiTest {
 
         // Starter server
         private lateinit var server: EmbeddedServer<NettyApplicationEngine, NettyApplicationEngine.Configuration>
+
+        private lateinit var dataSource: DataSource
+
+        private val ENHET_1 = "1234"
+        private val ENHET_2 = "1235"
 
         private val dbConfig = {
             DbConfig(
@@ -71,6 +77,7 @@ class FilterApiTest {
         @JvmStatic
         fun beforeAll() {
             postgres.start()
+            dataSource = initDatasource(dbConfig(), prometheus)
             server = embeddedServer(Netty, port = 0) {
                 server(dbConfig = dbConfig(), prometheus = prometheus)
             }.start()
@@ -83,6 +90,7 @@ class FilterApiTest {
         @AfterAll
         fun afterAll() {
             server.stop(0, 0)
+            dataSource.connection.close()
             postgres.close()
         }
     }
@@ -94,7 +102,7 @@ class FilterApiTest {
 
     private fun resetDatabase() {
         @Suppress("SqlWithoutWhere")
-        initDatasource(dbConfig(), prometheus).transaction {
+        dataSource.transaction {
             it.execute("DELETE FROM OPPGAVE_HISTORIKK")
             it.execute("DELETE FROM OPPGAVE")
             it.execute("DELETE FROM FILTER_AVKLARINGSBEHOVTYPE")
@@ -114,15 +122,16 @@ class FilterApiTest {
     @Test
     fun `Hente filter for enhet`() {
         opprettFiltre()
-        val filtre = hentFilterForEnhet(listOf("1234"))
+        val filtre = hentFilterForEnhet(listOf(ENHET_1))
 
         assertThat(filtre.size).isEqualTo(2)
-        assertThat(filtre.map { it.navn }).containsExactlyInAnyOrder("Simpelt filter", "Filter med enhet")
+        assertThat(filtre.map { it.navn }).contains("Simpelt filter", "Filter med enhet")
 
-        val filtre2 = hentFilterForEnhet(listOf("1235"))
+        val filtre2 = hentFilterForEnhet(listOf(ENHET_2))
 
         assertThat(filtre2.size).isEqualTo(1)
-        assertThat(filtre2.first().navn).isEqualTo("Simpelt filter")
+        assertThat(filtre2.map { it.navn }).contains("Simpelt filter")
+        assertThat(filtre2.map { it.navn }).doesNotContain("Filter med enhet")
     }
 
     private fun hentFilterForEnhet(enheter: List<String>): List<FilterResponse> {
@@ -141,7 +150,7 @@ class FilterApiTest {
     }
 
     private fun opprettFiltre() {
-        initDatasource(dbConfig(), prometheus).transaction { connection ->
+        dataSource.transaction { connection ->
             val filterRepo = FilterRepository(connection)
             filterRepo.opprett(
                 OpprettFilter(
@@ -158,7 +167,7 @@ class FilterApiTest {
                     beskrivelse = "Et filter for en spesifikk enhet",
                     opprettetAv = "test",
                     opprettetTidspunkt = LocalDateTime.now(),
-                    enhetFilter = listOf(EnhetFilter(enhetNr = "1234", filtermodus = Filtermodus.INKLUDER)),
+                    enhetFilter = listOf(EnhetFilter(enhetNr = ENHET_1, filtermodus = Filtermodus.INKLUDER)),
                     type = FilterTypeDto.GENERELL,
                 )
             )

--- a/app/src/test/kotlin/no/nav/aap/oppgave/OppgaveRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/oppgave/OppgaveRepositoryTest.kt
@@ -6,9 +6,7 @@ import no.nav.aap.komponenter.dbconnect.transaction
 import no.nav.aap.komponenter.dbtest.TestDataSource
 import no.nav.aap.oppgave.enhet.Enhet
 import no.nav.aap.oppgave.filter.Filter
-import no.nav.aap.oppgave.filter.FilterDto
 import no.nav.aap.oppgave.filter.FilterType
-import no.nav.aap.oppgave.filter.TransientFilterDto
 import no.nav.aap.oppgave.liste.OppgaveSorteringFelt
 import no.nav.aap.oppgave.liste.OppgaveSorteringRekkefølge
 import no.nav.aap.oppgave.liste.Paging
@@ -30,7 +28,7 @@ import java.math.BigDecimal
 import java.sql.SQLException
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.util.UUID
+import java.util.*
 import kotlin.test.fail
 
 class OppgaveRepositoryTest {
@@ -94,7 +92,8 @@ class OppgaveRepositoryTest {
 
         val oppgaverOppfølgingNay = dataSource.transaction { connection ->
             OppgaveRepository(connection).finnOppgaver(
-                filter = FilterDto(
+                filter = Filter(
+                    id = 1,
                     navn = "NAY oppfølgingsoppgave",
                     beskrivelse = "NAY oppfølgingsoppgave",
                     opprettetAv = "naboens katt",
@@ -108,7 +107,8 @@ class OppgaveRepositoryTest {
 
         val oppgaverOppfølgingNavKontor = dataSource.transaction { connection ->
             OppgaveRepository(connection).finnOppgaver(
-                filter = FilterDto(
+                filter = Filter(
+                    id = 1,
                     navn = "Oppfølgingsoppgave kontor",
                     beskrivelse = "Oppfølgingsoppgave kontor",
                     opprettetAv = "en geit",
@@ -141,7 +141,8 @@ class OppgaveRepositoryTest {
         }
         val oppgaverBeggeEnheter = dataSource.transaction { connection ->
             OppgaveRepository(connection).finnOppgaver(
-                filter = FilterDto(
+                filter = Filter(
+                    id = 1,
                     navn = "alle oppgaver",
                     beskrivelse = "alle oppgaver",
                     opprettetAv = "saksbehandler",
@@ -162,7 +163,8 @@ class OppgaveRepositoryTest {
 
         val oppgaverLørenskog = dataSource.transaction { connection ->
             OppgaveRepository(connection).finnOppgaver(
-                filter = FilterDto(
+                filter = Filter(
+                    id = 1,
                     navn = "alle oppgaver",
                     beskrivelse = "alle oppgaver",
                     opprettetAv = "saksbehandler",
@@ -236,7 +238,7 @@ class OppgaveRepositoryTest {
         val oppgaveId2 = opprettOppgave(veilederArbeid = VEILEDER_IDENT_1)
 
         val oppgaver = finnLedigeOppgaver(
-            TransientFilterDto(
+            filter(
                 veileder = VEILEDER_IDENT_1,
                 enheter = setOf(ENHET_NAV_LØRENSKOG)
             )
@@ -252,7 +254,7 @@ class OppgaveRepositoryTest {
         val oppgaveId2 = opprettOppgave(veilederArbeid = VEILEDER_IDENT_1)
 
         val oppgaver = finnLedigeOppgaver(
-            TransientFilterDto(
+            filter(
                 veileder = VEILEDER_IDENT_1,
                 enheter = setOf(ENHET_NAV_LØRENSKOG)
             )
@@ -269,7 +271,7 @@ class OppgaveRepositoryTest {
         val oppgaveId3 = opprettOppgave(veilederSykdom = VEILEDER_IDENT_1)
 
         val oppgaver = finnLedigeOppgaver(
-            TransientFilterDto(
+            filter(
                 veileder = VEILEDER_IDENT_1,
                 enheter = setOf(ENHET_NAV_LØRENSKOG)
             )
@@ -300,7 +302,7 @@ class OppgaveRepositoryTest {
         val oppgaveId2 = opprettOppgave(enhet = ENHET_NAV_LØRENSKOG)
         val oppgaveId3 = opprettOppgave(enhet = ENHET_NAV_LØRENSKOG)
 
-        val oppgaver = finnLedigeOppgaver(TransientFilterDto(enheter = setOf(ENHET_NAV_LØRENSKOG))).oppgaver
+        val oppgaver = finnLedigeOppgaver(filter(enheter = setOf(ENHET_NAV_LØRENSKOG))).oppgaver
 
         assertThat(oppgaver).hasSize(2)
         assertThat(oppgaver.map { it.id }[0]).isEqualTo(oppgaveId2.id)
@@ -309,7 +311,7 @@ class OppgaveRepositoryTest {
 
     @Test
     fun `Kan bruke paging`() {
-        val søkUtenTreff = finnLedigeOppgaver(TransientFilterDto(enheter = setOf(ENHET_NAV_LILLESTRØM)))
+        val søkUtenTreff = finnLedigeOppgaver(filter(enheter = setOf(ENHET_NAV_LILLESTRØM)))
         assertThat(søkUtenTreff.oppgaver).hasSize(0)
         assertThat(søkUtenTreff.antallGjenstaaende).isEqualTo(0)
 
@@ -319,22 +321,22 @@ class OppgaveRepositoryTest {
         val oppgave3 = opprettOppgave(enhet = ENHET_NAV_ENEBAKK)
         val oppgave4 = opprettOppgave(enhet = ENHET_NAV_ENEBAKK)
 
-        val søkUtenPaging = finnLedigeOppgaver(TransientFilterDto(enheter = setOf(ENHET_NAV_ENEBAKK)))
+        val søkUtenPaging = finnLedigeOppgaver(filter(enheter = setOf(ENHET_NAV_ENEBAKK)))
         assertThat(søkUtenPaging.oppgaver).hasSize(4)
         assertThat(søkUtenPaging.antallGjenstaaende).isEqualTo(0)
 
         val søkMedPaging =
-            finnLedigeOppgaver(TransientFilterDto(enheter = setOf(ENHET_NAV_ENEBAKK)), paging = Paging(1, 1))
+            finnLedigeOppgaver(filter(enheter = setOf(ENHET_NAV_ENEBAKK)), paging = Paging(1, 1))
         assertThat(søkMedPaging.oppgaver).hasSize(1)
         assertThat(søkMedPaging.antallGjenstaaende).isEqualTo(3)
 
         val søkMedPagingPå10 =
-            finnLedigeOppgaver(TransientFilterDto(enheter = setOf(ENHET_NAV_ENEBAKK)), paging = Paging(1, 10))
+            finnLedigeOppgaver(filter(enheter = setOf(ENHET_NAV_ENEBAKK)), paging = Paging(1, 10))
         assertThat(søkMedPagingPå10.oppgaver).hasSize(4)
         assertThat(søkMedPagingPå10.antallGjenstaaende).isEqualTo(0)
 
         val søkMedPagingSomIkkeFinnes =
-            finnLedigeOppgaver(TransientFilterDto(enheter = setOf(ENHET_NAV_ENEBAKK)), paging = Paging(2, 25))
+            finnLedigeOppgaver(filter(enheter = setOf(ENHET_NAV_ENEBAKK)), paging = Paging(2, 25))
         assertThat(søkMedPagingSomIkkeFinnes.oppgaver).hasSize(0)
         assertThat(søkMedPagingSomIkkeFinnes.antallGjenstaaende).isEqualTo(0)
 
@@ -352,7 +354,7 @@ class OppgaveRepositoryTest {
         opprettOppgave(enhet = ENHET_NAV_ENEBAKK)
 
         // Hent side 2 med 2 oppgaver per side — kun 2 oppgaver returneres, men totalen skal være 4
-        val side2 = finnLedigeOppgaver(TransientFilterDto(enheter = setOf(ENHET_NAV_ENEBAKK)), paging = Paging(2, 2))
+        val side2 = finnLedigeOppgaver(filter(enheter = setOf(ENHET_NAV_ENEBAKK)), paging = Paging(2, 2))
         assertThat(side2.oppgaver).hasSize(2)
         assertThat(side2.antallTotalt).isEqualTo(4)
     }
@@ -396,7 +398,7 @@ class OppgaveRepositoryTest {
 
         // Sorter på behandling_opprettet stigende
         val oppgavelisteBehandlingOpprettetAsc = finnAlleOppgaverMedSortering(
-            TransientFilterDto(enheter = setOf(ENHET_NAV_ENEBAKK)),
+            filter(enheter = setOf(ENHET_NAV_ENEBAKK)),
             null,
             OppgaveSorteringFelt.BEHANDLING_OPPRETTET,
             OppgaveSorteringRekkefølge.ASC
@@ -406,7 +408,7 @@ class OppgaveRepositoryTest {
 
         // Sorter på behandling_opprettet synkende
         val oppgavelisteBehandlingOpprettetDesc = finnAlleOppgaverMedSortering(
-            TransientFilterDto(enheter = setOf(ENHET_NAV_ENEBAKK)),
+            filter(enheter = setOf(ENHET_NAV_ENEBAKK)),
             null,
             OppgaveSorteringFelt.BEHANDLING_OPPRETTET,
             OppgaveSorteringRekkefølge.DESC
@@ -416,7 +418,7 @@ class OppgaveRepositoryTest {
 
         // Sorter på behandlingstype stigende
         val oppgavelisteBehandlingstypeAsc = finnAlleOppgaverMedSortering(
-            TransientFilterDto(enheter = setOf(ENHET_NAV_ENEBAKK)),
+            filter(enheter = setOf(ENHET_NAV_ENEBAKK)),
             null,
             OppgaveSorteringFelt.BEHANDLINGSTYPE,
             OppgaveSorteringRekkefølge.ASC
@@ -426,7 +428,7 @@ class OppgaveRepositoryTest {
 
         // Sorter på behandling_opprettet synkende
         val oppgavelisteBehandlingstyperDesc = finnAlleOppgaverMedSortering(
-            TransientFilterDto(enheter = setOf(ENHET_NAV_ENEBAKK)),
+            filter(enheter = setOf(ENHET_NAV_ENEBAKK)),
             null,
             OppgaveSorteringFelt.BEHANDLINGSTYPE,
             OppgaveSorteringRekkefølge.DESC
@@ -463,7 +465,7 @@ class OppgaveRepositoryTest {
 
         // Sorter på behandling_opprettet stigende side 1
         val oppgavelisteBehandlingOpprettetAscEn = finnAlleOppgaverMedSortering(
-            TransientFilterDto(enheter = setOf(ENHET_NAV_ENEBAKK)),
+            filter(enheter = setOf(ENHET_NAV_ENEBAKK)),
             Paging(side = 1, antallPerSide = 3),
             OppgaveSorteringFelt.BEHANDLING_OPPRETTET,
             OppgaveSorteringRekkefølge.ASC
@@ -474,7 +476,7 @@ class OppgaveRepositoryTest {
 
         // Sorter på behandling_opprettet stigende side 2
         val oppgavelisteBehandlingOpprettetAscTo = finnAlleOppgaverMedSortering(
-            TransientFilterDto(enheter = setOf(ENHET_NAV_ENEBAKK)),
+            filter(enheter = setOf(ENHET_NAV_ENEBAKK)),
             Paging(side = 2, antallPerSide = 3),
             OppgaveSorteringFelt.BEHANDLING_OPPRETTET,
             OppgaveSorteringRekkefølge.ASC
@@ -485,7 +487,7 @@ class OppgaveRepositoryTest {
 
         // Sorter på behandling_opprettet stigende side 3
         val oppgavelisteBehandlingOpprettetAscTre = finnAlleOppgaverMedSortering(
-            TransientFilterDto(enheter = setOf(ENHET_NAV_ENEBAKK)),
+            filter(enheter = setOf(ENHET_NAV_ENEBAKK)),
             Paging(side = 3, antallPerSide = 3),
             OppgaveSorteringFelt.BEHANDLING_OPPRETTET,
             OppgaveSorteringRekkefølge.ASC
@@ -511,7 +513,7 @@ class OppgaveRepositoryTest {
 
         // skal kun inneholde ledig oppgave
         val ledigeOppgaver = finnLedigeOppgaver(
-            filter = TransientFilterDto(enheter = setOf(ENHET_NAV_ENEBAKK)),
+            filter = filter(enheter = setOf(ENHET_NAV_ENEBAKK)),
         )
         assertThat(ledigeOppgaver.oppgaver.first().id == ledigOppgaveId.id)
         assertThat(ledigeOppgaver.oppgaver.map { it.id }.contains(oppgavePåVentId.id)).isFalse()
@@ -519,7 +521,7 @@ class OppgaveRepositoryTest {
 
         // skal inneholde ledig, reservert og på vent
         val alleOppgaver = finnAlleOppgaver(
-            filter = TransientFilterDto(enheter = setOf(ENHET_NAV_ENEBAKK)),
+            filter = filter(enheter = setOf(ENHET_NAV_ENEBAKK)),
         )
         assertThat(alleOppgaver.oppgaver).hasSize(3)
         assertThat(reservertOppgaveId.id in alleOppgaver.oppgaver.map { it.id })
@@ -688,50 +690,50 @@ class OppgaveRepositoryTest {
         )
 
         val merEnnSøkInk = finnAlleOppgaverMedUtvidetFilter(
-            filter = TransientFilterDto(enheter = setOf(ENHET_NAV_ENEBAKK)),
+            filter = filter(enheter = setOf(ENHET_NAV_ENEBAKK)),
             paging = null,
             utvidetOppgavelisteFilter = utvidetFilterMerEnnEksludert,
         )
 
         val merEnnSøkEks = finnAlleOppgaverMedUtvidetFilter(
-            filter = TransientFilterDto(enheter = setOf(ENHET_NAV_ENEBAKK)),
+            filter = filter(enheter = setOf(ENHET_NAV_ENEBAKK)),
             paging = null,
             utvidetOppgavelisteFilter = utvidetFilterMerEnnInkludert,
         )
 
 
         val søkMedUtvidetFilter = finnAlleOppgaverMedUtvidetFilter(
-            filter = TransientFilterDto(enheter = setOf(ENHET_NAV_ENEBAKK)),
+            filter = filter(enheter = setOf(ENHET_NAV_ENEBAKK)),
             paging = null,
             utvidetOppgavelisteFilter = utvidetFilter,
         )
 
         val søkMedUtvidetFilterPåVent = finnAlleOppgaverMedUtvidetFilter(
-            filter = TransientFilterDto(enheter = setOf(ENHET_NAV_ENEBAKK)),
+            filter = filter(enheter = setOf(ENHET_NAV_ENEBAKK)),
             paging = null,
             utvidetOppgavelisteFilter = utvidetFilterMedStatusPåVent,
         )
 
         val søkMedutvidetFilterMedStatusPåVentOgReturStatus = finnAlleOppgaverMedUtvidetFilter(
-            filter = TransientFilterDto(enheter = setOf(ENHET_NAV_ENEBAKK)),
+            filter = filter(enheter = setOf(ENHET_NAV_ENEBAKK)),
             paging = null,
             utvidetOppgavelisteFilter = utvidetFilterMedStatusPåVentOgReturStatus,
         )
 
         val søkMedUtvidetFilterVentefristUtløpt = finnAlleOppgaverMedUtvidetFilter(
-            filter = TransientFilterDto(enheter = setOf(ENHET_NAV_ENEBAKK)),
+            filter = filter(enheter = setOf(ENHET_NAV_ENEBAKK)),
             paging = null,
             utvidetOppgavelisteFilter = utvidetFilterMedStatusVentefristUtløpt
         )
 
         val søkMedUtvidetFilterHastesøk = finnAlleOppgaverMedUtvidetFilter(
-            filter = TransientFilterDto(enheter = setOf(ENHET_NAV_ENEBAKK)),
+            filter = filter(enheter = setOf(ENHET_NAV_ENEBAKK)),
             paging = null,
             utvidetOppgavelisteFilter = utvidetFilterMedHastesøk,
         )
 
         val alleOppgaver = finnAlleOppgaver(
-            filter = TransientFilterDto(
+            filter = filter(
                 enheter = setOf(ENHET_NAV_ENEBAKK)
             )
         )
@@ -763,7 +765,7 @@ class OppgaveRepositoryTest {
         )
 
         val resultat = finnAlleOppgaverMedUtvidetFilter(
-            filter = TransientFilterDto(enheter = setOf(ENHET_NAV_ENEBAKK)),
+            filter = filter(enheter = setOf(ENHET_NAV_ENEBAKK)),
             utvidetOppgavelisteFilter = UtvidetOppgavelisteFilter(
                 fom = LocalDate.of(2024, 1, 10),
                 tom = LocalDate.of(2024, 1, 20)
@@ -790,15 +792,15 @@ class OppgaveRepositoryTest {
         val filterUnderBeløp = UtvidetOppgavelisteFilter(beløpMerEnn = BigDecimal("999.99"))
 
         val resultatEksakt = finnAlleOppgaverMedUtvidetFilter(
-            filter = TransientFilterDto(enheter = setOf(ENHET_NAV_ENEBAKK)),
+            filter = filter(enheter = setOf(ENHET_NAV_ENEBAKK)),
             utvidetOppgavelisteFilter = filterEksaktBeløp,
         )
         val resultatOver = finnAlleOppgaverMedUtvidetFilter(
-            filter = TransientFilterDto(enheter = setOf(ENHET_NAV_ENEBAKK)),
+            filter = filter(enheter = setOf(ENHET_NAV_ENEBAKK)),
             utvidetOppgavelisteFilter = filterOverBeløp,
         )
         val resultatUnder = finnAlleOppgaverMedUtvidetFilter(
-            filter = TransientFilterDto(enheter = setOf(ENHET_NAV_ENEBAKK)),
+            filter = filter(enheter = setOf(ENHET_NAV_ENEBAKK)),
             utvidetOppgavelisteFilter = filterUnderBeløp,
         )
 
@@ -824,15 +826,15 @@ class OppgaveRepositoryTest {
         val filterUnderBeløp = UtvidetOppgavelisteFilter(beløpMindreEnn = BigDecimal("999.99"))
 
         val resultatEksakt = finnAlleOppgaverMedUtvidetFilter(
-            filter = TransientFilterDto(enheter = setOf(ENHET_NAV_ENEBAKK)),
+            filter = filter(enheter = setOf(ENHET_NAV_ENEBAKK)),
             utvidetOppgavelisteFilter = filterEksaktBeløp,
         )
         val resultatOver = finnAlleOppgaverMedUtvidetFilter(
-            filter = TransientFilterDto(enheter = setOf(ENHET_NAV_ENEBAKK)),
+            filter = filter(enheter = setOf(ENHET_NAV_ENEBAKK)),
             utvidetOppgavelisteFilter = filterOverBeløp,
         )
         val resultatUnder = finnAlleOppgaverMedUtvidetFilter(
-            filter = TransientFilterDto(enheter = setOf(ENHET_NAV_ENEBAKK)),
+            filter = filter(enheter = setOf(ENHET_NAV_ENEBAKK)),
             utvidetOppgavelisteFilter = filterUnderBeløp,
         )
 
@@ -867,15 +869,15 @@ class OppgaveRepositoryTest {
         )
 
         val resultatInkludert = finnAlleOppgaverMedUtvidetFilter(
-            filter = TransientFilterDto(enheter = setOf(ENHET_NAV_ENEBAKK)),
+            filter = filter(enheter = setOf(ENHET_NAV_ENEBAKK)),
             utvidetOppgavelisteFilter = filterInkludert,
         )
         val resultatEksluderPgaMerEnn = finnAlleOppgaverMedUtvidetFilter(
-            filter = TransientFilterDto(enheter = setOf(ENHET_NAV_ENEBAKK)),
+            filter = filter(enheter = setOf(ENHET_NAV_ENEBAKK)),
             utvidetOppgavelisteFilter = filterEksluderPgaMerEnn,
         )
         val resultatEksluderPgaMindreEnn = finnAlleOppgaverMedUtvidetFilter(
-            filter = TransientFilterDto(enheter = setOf(ENHET_NAV_ENEBAKK)),
+            filter = filter(enheter = setOf(ENHET_NAV_ENEBAKK)),
             utvidetOppgavelisteFilter = filterEksluderPgaMindreEnn,
         )
 
@@ -911,7 +913,7 @@ class OppgaveRepositoryTest {
 
         // Lovvalg-medlemskap-kø skal bare inneholde lovvalgsoppgaven
         val oppgavelisteLovvalg = finnAlleOppgaverMedUtvidetFilter(
-            filter = TransientFilterDto(
+            filter = filter(
                 enheter = setOf("4491"),
                 avklaringsbehovKoder = setOf(Definisjon.AVKLAR_LOVVALG_MEDLEMSKAP.kode.name)
             ),
@@ -929,7 +931,7 @@ class OppgaveRepositoryTest {
         assertThat(oppgavelisteLovvalg.oppgaver.first().id).isEqualTo(oppgaveLovvalg.id)
 
         val oppgavelisteHeleNAY = finnAlleOppgaverMedUtvidetFilter(
-            filter = TransientFilterDto(enheter = setOf("4491"), avklaringsbehovKoder = emptySet()),
+            filter = filter(enheter = setOf("4491"), avklaringsbehovKoder = emptySet()),
             paging = null,
             utvidetOppgavelisteFilter = UtvidetOppgavelisteFilter(
                 årsaker = setOf(),
@@ -943,7 +945,7 @@ class OppgaveRepositoryTest {
         assertThat(oppgavelisteHeleNAY.oppgaver).hasSize(4)
 
         val oppgavelisteBeslutter = finnAlleOppgaverMedUtvidetFilter(
-            filter = TransientFilterDto(
+            filter = filter(
                 enheter = setOf("4491"), avklaringsbehovKoder = setOf(
                     Definisjon.FATTE_VEDTAK.kode.name,
                     Definisjon.SKRIV_VEDTAKSBREV.kode.name
@@ -963,7 +965,7 @@ class OppgaveRepositoryTest {
 
         // Skal kunne filtrere beslutter-køen på spesifikk beslutter-oppgave
         val oppgavelisteBeslutterBareVedtaksbrev = finnAlleOppgaverMedUtvidetFilter(
-            filter = TransientFilterDto(
+            filter = filter(
                 enheter = setOf("4491"), avklaringsbehovKoder = setOf(
                     Definisjon.FATTE_VEDTAK.kode.name,
                     Definisjon.SKRIV_VEDTAKSBREV.kode.name
@@ -983,7 +985,7 @@ class OppgaveRepositoryTest {
 
         // Om man prøver å filtrere på en avklaringsbehovkode som ikke er i køen, returneres ingen oppgaver
         val oppgavelisteRequestInkonsistenteverdier = finnAlleOppgaverMedUtvidetFilter(
-            filter = TransientFilterDto(
+            filter = filter(
                 enheter = setOf("4491"), avklaringsbehovKoder = setOf(
                     Definisjon.FATTE_VEDTAK.kode.name,
                     Definisjon.SKRIV_VEDTAKSBREV.kode.name
@@ -1008,7 +1010,7 @@ class OppgaveRepositoryTest {
         val oppgaveId2 = opprettOppgave(enhet = ENHET_NAV_LØRENSKOG, oppfølgingsenhet = ENHET_NAV_LILLESTRØM)
         opprettOppgave(enhet = ENHET_NAV_LØRENSKOG)
 
-        val oppgaver = finnLedigeOppgaver(TransientFilterDto(enheter = setOf(ENHET_NAV_LILLESTRØM))).oppgaver
+        val oppgaver = finnLedigeOppgaver(filter(enheter = setOf(ENHET_NAV_LILLESTRØM))).oppgaver
 
         assertThat(oppgaver).hasSize(1)
         assertThat(oppgaver.map { it.id }).contains(oppgaveId2.id)
@@ -1078,13 +1080,13 @@ class OppgaveRepositoryTest {
         )
         val vanligOppgave1 =
             opprettOppgave(enhet = ENHET_NAV_ENEBAKK, behandlingOpprettet = LocalDateTime.now().minusDays(10))
-        
+
         val avslag115oppgave = opprettOppgave(
             behandlingRef = avslag11_5Behandlingref,
             enhet = ENHET_NAV_ENEBAKK,
             behandlingOpprettet = LocalDateTime.now()
         )
-        
+
         val vanligOppgave2 =
             opprettOppgave(enhet = ENHET_NAV_ENEBAKK, behandlingOpprettet = LocalDateTime.now().plusDays(10))
         val vanligOppgave3 = opprettOppgave(enhet = ENHET_NAV_ENEBAKK)
@@ -1092,7 +1094,7 @@ class OppgaveRepositoryTest {
 
         val søkMedPaging2PåBehandlingOpprettetNyesteFørst =
             finnLedigeOppgaver(
-                TransientFilterDto(enheter = setOf(ENHET_NAV_ENEBAKK)),
+                filter(enheter = setOf(ENHET_NAV_ENEBAKK)),
                 paging = Paging(1, 2),
                 sortBy = OppgaveSorteringFelt.BEHANDLING_OPPRETTET,
                 rekkefølge = OppgaveSorteringRekkefølge.DESC
@@ -1106,7 +1108,7 @@ class OppgaveRepositoryTest {
 
         val søkMedPaging5PåBehandlingOpprettetNyesteFørst =
             finnLedigeOppgaver(
-                TransientFilterDto(enheter = setOf(ENHET_NAV_ENEBAKK)),
+                filter(enheter = setOf(ENHET_NAV_ENEBAKK)),
                 paging = Paging(1, 5),
                 sortBy = OppgaveSorteringFelt.BEHANDLING_OPPRETTET,
                 rekkefølge = OppgaveSorteringRekkefølge.DESC
@@ -1119,7 +1121,7 @@ class OppgaveRepositoryTest {
 
         val søkMedPaging10PåBehandlingOpprettetEldsteFørst =
             finnLedigeOppgaver(
-                TransientFilterDto(enheter = setOf(ENHET_NAV_ENEBAKK)),
+                filter(enheter = setOf(ENHET_NAV_ENEBAKK)),
                 paging = Paging(1, 10),
                 sortBy = OppgaveSorteringFelt.BEHANDLING_OPPRETTET,
                 rekkefølge = OppgaveSorteringRekkefølge.ASC
@@ -1144,7 +1146,7 @@ class OppgaveRepositoryTest {
 
         val søkPåBehandlingOpprettetNyesteFørst =
             finnLedigeOppgaver(
-                TransientFilterDto(enheter = setOf(ENHET_NAV_ENEBAKK)),
+                filter(enheter = setOf(ENHET_NAV_ENEBAKK)),
                 sortBy = OppgaveSorteringFelt.BEHANDLING_OPPRETTET,
                 rekkefølge = OppgaveSorteringRekkefølge.DESC
             )
@@ -1157,7 +1159,7 @@ class OppgaveRepositoryTest {
 
         val søkPåBehandlingOpprettetNyesteFørst2 =
             finnLedigeOppgaver(
-                TransientFilterDto(enheter = setOf(ENHET_NAV_ENEBAKK)),
+                filter(enheter = setOf(ENHET_NAV_ENEBAKK)),
                 sortBy = OppgaveSorteringFelt.BEHANDLING_OPPRETTET,
                 rekkefølge = OppgaveSorteringRekkefølge.DESC
             )
@@ -1180,12 +1182,15 @@ class OppgaveRepositoryTest {
         markerOppgave(avslag115Ref, MarkeringForBehandling.AVSLAG_11_5)
 
         val hasterResultat = finnAlleOppgaver(
-            TransientFilterDto(enheter = setOf(ENHET_NAV_ENEBAKK), inkluderteMarkeringer = setOf(MarkeringForBehandling.HASTER))
+            filter(
+                enheter = setOf(ENHET_NAV_ENEBAKK),
+                inkluderteMarkeringer = setOf(MarkeringForBehandling.HASTER)
+            )
         )
         assertThat(hasterResultat.oppgaver.map { it.id }).containsExactly(hasteOppgave.id)
 
         val avslagResultat = finnAlleOppgaver(
-            TransientFilterDto(
+            filter(
                 enheter = setOf(ENHET_NAV_ENEBAKK),
                 inkluderteMarkeringer = setOf(MarkeringForBehandling.AVSLAG_11_5)
             )
@@ -1207,7 +1212,7 @@ class OppgaveRepositoryTest {
         markerOppgave(spesialRef, MarkeringForBehandling.AVSLAG_11_5)
 
         val resultat = finnAlleOppgaver(
-            TransientFilterDto(
+            filter(
                 enheter = setOf(ENHET_NAV_ENEBAKK),
                 inkluderteMarkeringer = setOf(MarkeringForBehandling.HASTER, MarkeringForBehandling.AVSLAG_11_5)
             )
@@ -1228,7 +1233,7 @@ class OppgaveRepositoryTest {
         markerOppgave(hasteRef, MarkeringForBehandling.HASTER)
 
         val resultat = finnAlleOppgaver(
-            TransientFilterDto(enheter = setOf(ENHET_NAV_ENEBAKK), inkluderteMarkeringer = emptySet())
+            filter(enheter = setOf(ENHET_NAV_ENEBAKK), inkluderteMarkeringer = emptySet())
         )
 
         assertThat(resultat.oppgaver).hasSize(2)
@@ -1249,7 +1254,7 @@ class OppgaveRepositoryTest {
 
         // Ekskluder HASTER — skal returnere avslag115 og umarkert, men ikke haste
         val utenHaste = finnAlleOppgaver(
-            TransientFilterDto(
+            filter(
                 enheter = setOf(ENHET_NAV_ENEBAKK),
                 ekskluderteMarkeringer = setOf(MarkeringForBehandling.HASTER)
             )
@@ -1259,7 +1264,7 @@ class OppgaveRepositoryTest {
 
         // Ekskluder begge — skal kun returnere umarkert
         val utenBegge = finnAlleOppgaver(
-            TransientFilterDto(
+            filter(
                 enheter = setOf(ENHET_NAV_ENEBAKK),
                 ekskluderteMarkeringer = setOf(MarkeringForBehandling.HASTER, MarkeringForBehandling.AVSLAG_11_5)
             )
@@ -1356,7 +1361,7 @@ class OppgaveRepositoryTest {
                 antallTotalt = 0
             )
         }
-        val kombinertFilter = (filter as TransientFilterDto).copy(
+        val kombinertFilter = filter.copy(
             behandlingstyper = utvidetOppgavelisteFilter.behandlingstyper,
             avklaringsbehovKoder = avklaringsbehovKoder,
         )
@@ -1382,7 +1387,13 @@ class OppgaveRepositoryTest {
             val markeringRepository = MarkeringRepository(connection)
             markeringRepository.lagreMarkeringHendelse(
                 hasterBehandlingsref,
-                BehandlingMarkering(MarkeringForBehandling.HASTER, "haster", opprettetAv = "me", opprettetTidspunkt = LocalDateTime.now(), hendelseType = MarkeringHendelseType.OPPRETTET)
+                BehandlingMarkering(
+                    MarkeringForBehandling.HASTER,
+                    "haster",
+                    opprettetAv = "me",
+                    opprettetTidspunkt = LocalDateTime.now(),
+                    hendelseType = MarkeringHendelseType.OPPRETTET
+                )
             )
         }
     }
@@ -1392,7 +1403,13 @@ class OppgaveRepositoryTest {
             val markeringRepository = MarkeringRepository(connection)
             markeringRepository.lagreMarkeringHendelse(
                 hasterBehandlingsref,
-                BehandlingMarkering(MarkeringForBehandling.HASTER, "haster", opprettetAv = "me", opprettetTidspunkt = LocalDateTime.now(), hendelseType = MarkeringHendelseType.FJERNET)
+                BehandlingMarkering(
+                    MarkeringForBehandling.HASTER,
+                    "haster",
+                    opprettetAv = "me",
+                    opprettetTidspunkt = LocalDateTime.now(),
+                    hendelseType = MarkeringHendelseType.FJERNET
+                )
             )
         }
     }
@@ -1401,7 +1418,13 @@ class OppgaveRepositoryTest {
         dataSource.transaction { connection ->
             MarkeringRepository(connection).lagreMarkeringHendelse(
                 behandlingRef,
-                BehandlingMarkering(markeringType, "begrunnelse", "test", opprettetTidspunkt = LocalDateTime.now(), hendelseType = MarkeringHendelseType.OPPRETTET)
+                BehandlingMarkering(
+                    markeringType,
+                    "begrunnelse",
+                    "test",
+                    opprettetTidspunkt = LocalDateTime.now(),
+                    hendelseType = MarkeringHendelseType.OPPRETTET
+                )
             )
         }
     }
@@ -1433,6 +1456,33 @@ class OppgaveRepositoryTest {
         return dataSource.transaction { connection ->
             OppgaveRepository(connection).hentOppgave(oppgaveId.id)
         }
+    }
+
+    private fun filter(
+        avklaringsbehovKoder: Set<String> = emptySet(),
+        behandlingstyper: Set<Behandlingstype> = emptySet(),
+        enheter: Set<String> = emptySet(),
+        veileder: String? = null,
+        inkluderteMarkeringer: Set<MarkeringForBehandling> = emptySet(),
+        ekskluderteMarkeringer: Set<MarkeringForBehandling> = emptySet(),
+        type: FilterType = FilterType.GENERELL,
+        ): Filter {
+        return Filter(
+            id = 1,
+            navn = "navn",
+            beskrivelse = "beskrivelse",
+            avklaringsbehovKoder = avklaringsbehovKoder,
+            behandlingstyper = behandlingstyper,
+            enheter = enheter,
+            veileder = veileder,
+            inkluderteMarkeringer = inkluderteMarkeringer,
+            ekskluderteMarkeringer = ekskluderteMarkeringer,
+            type = type,
+            opprettetAv = "saksbehandler",
+            opprettetTidspunkt = LocalDateTime.now().minusDays(10),
+            endretAv = "saksbehandler",
+            endretTidspunkt = LocalDateTime.now().minusDays(5)
+        )
     }
 
     private fun opprettOppgave(

--- a/app/src/test/kotlin/no/nav/aap/oppgave/filter/FilterRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/oppgave/filter/FilterRepositoryTest.kt
@@ -105,9 +105,8 @@ internal class FilterRepositoryTest {
                 beskrivelse = "Filter for avklar sykdom oppgave",
                 opprettetAv = "test",
                 opprettetTidspunkt = LocalDateTime.now(),
-                avklaringsbehovtyper = setOf(Definisjon.AVKLAR_SYKDOM.kode.name)
+                avklaringsbehovKoder = setOf(Definisjon.AVKLAR_SYKDOM.kode.name)
             )
-            val antallFilterFørTest = filterRepo.hentAlle().size
             val opprettetFilterId = filterRepo.opprett(nyttFilter)
 
             val opprettetFilter = filterRepo.hent(opprettetFilterId)!!
@@ -151,7 +150,7 @@ internal class FilterRepositoryTest {
                 opprettetAv = "test1",
                 opprettetTidspunkt = LocalDateTime.now(),
                 behandlingstyper = setOf(Behandlingstype.FØRSTEGANGSBEHANDLING),
-                avklaringsbehovtyper = setOf(Definisjon.AVKLAR_SYKDOM.kode.name),
+                avklaringsbehovKoder = setOf(Definisjon.AVKLAR_SYKDOM.kode.name),
                 enhetFilter = listOf(EnhetFilter("4491", Filtermodus.INKLUDER))
             )
 
@@ -189,7 +188,6 @@ internal class FilterRepositoryTest {
 
             alleFilter = filterRepo.hentAlle()
             assertThat(alleFilter).hasSize(1)
-            hentetFilter = alleFilter.first()
             assertThat(filterRepo.hentAlle()).hasSize(antallFilterFørTest + 1)
             hentetFilter = requireNotNull(filterRepo.hent(filterId))
             assertThat(hentetFilter.navn).isEqualTo("Filter for avklar barnetillegg og revurdering")
@@ -232,7 +230,7 @@ internal class FilterRepositoryTest {
                 beskrivelse = "Kvalitetssikringsfilter",
                 opprettetAv = "test",
                 opprettetTidspunkt = LocalDateTime.now(),
-                type = FilterType.KVALITETSSIKRING
+                type = FilterTypeDto.KVALITETSSIKRING
             )
             val filterId = filterRepo.opprett(nyttFilter)
 

--- a/app/src/test/kotlin/no/nav/aap/oppgave/filter/FilterRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/oppgave/filter/FilterRepositoryTest.kt
@@ -176,7 +176,7 @@ internal class FilterRepositoryTest {
                 navn = "Filter for avklar barnetillegg og revurdering",
                 beskrivelse = "Filter for avklar barnetillegg og revurdering",
                 behandlingstyper = setOf(Behandlingstype.REVURDERING),
-                avklaringsbehovtyper = setOf(Definisjon.AVKLAR_BARNETILLEGG.kode.name),
+                avklaringsbehovKoder = setOf(Definisjon.AVKLAR_BARNETILLEGG.kode.name),
                 enhetFilter = listOf(
                     EnhetFilter("ALLE", Filtermodus.INKLUDER),
                     EnhetFilter("4402", Filtermodus.EKSKLUDER),


### PR DESCRIPTION
..og lager en V2 av filterDto + endepunkt med bare feltene frontend trenger.

Sletter endepunkter for oppretting, oppdatering og sletting av filter som ble laget i 2024 og fortsatt ikke er tatt i bruk (paw patrol har samme funksjonalitet men bruker egne endepunkter). Jeg tror det er lettere å lage dem på nytt når funksjonaliteten trengs enn å skrive om.