### PR TITLE
AAP-2383: Støtte overstyring av visningsnavn

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/oppgave/drift/DriftApi.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/drift/DriftApi.kt
@@ -51,7 +51,6 @@ fun NormalOpenAPIRoute.driftApi(
                         OppgaveRepository(connection),
                         MarkeringRepository(connection),
                         enhetService,
-                        norgGateway
                     )
                         .hentOppgaverForBehandling(params.referanse)
                         .map { it.mapTilOppgaveDriftsinfo(historikkRepository.hentHistorikkForOppgave(it.id!!)) }

--- a/app/src/main/kotlin/no/nav/aap/oppgave/enhet/Enhet.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/enhet/Enhet.kt
@@ -1,11 +1,11 @@
 package no.nav.aap.oppgave.enhet
 
-enum class Enhet(val kode: String) {
+enum class Enhet(val kode: String, val visningsnavn: String? = null) {
     NAV_VIKAFOSSEN("2103"),
     NAY("4491"),
     NAY_EGNE_ANSATTE("4483"),
     NAV_UTLAND("0393"),
-    NAY_UTLAND("4402"),
+    NAY_UTLAND("4402", "Nav arbeid og ytelser Utland"),
     NASJONAL_OPPFØLGINGSENHET("4154"),
     NAV_REGION_SUNNFJORD("1476"),
     NAV_KINN("1401"),

--- a/app/src/main/kotlin/no/nav/aap/oppgave/enhet/EnhetAPI.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/enhet/EnhetAPI.kt
@@ -34,14 +34,13 @@ import javax.sql.DataSource
 
 fun NormalOpenAPIRoute.hentEnhetApi(
     enhetService: EnhetService,
-    norgGateway: NorgGateway,
     prometheus: PrometheusMeterRegistry
 ) {
     route("/enheter").get<Unit, List<EnhetDto>> {
         prometheus.httpCallCounter("/enheter").increment()
 
-        val enheter = enhetService.hentEnheter(ident(), token())
-        val enhetNrTilNavn = norgGateway.hentEnheter()
+        val enheter = enhetService.hentEnheterForIdent(ident(), token())
+        val enhetNrTilNavn = enhetService.hentEnheterMedNavn()
         val enheterMedNavn = enheter.map { EnhetDto(it, enhetNrTilNavn[it] ?: "") }
 
         respond(enheterMedNavn)

--- a/app/src/main/kotlin/no/nav/aap/oppgave/enhet/EnhetService.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/enhet/EnhetService.kt
@@ -40,7 +40,7 @@ enum class FylkesenheterSomSkalBehandleKlager(val enhetsnummer: String) {
 }
 
 interface IEnhetService {
-    fun hentEnheter(ident: String, currentToken: OidcToken): List<String>
+    fun hentEnheterForIdent(ident: String, currentToken: OidcToken): List<String>
     fun utledEnhetForOppgave(
         avklaringsbehovKode: AvklaringsbehovKode,
         ident: String?,
@@ -68,7 +68,7 @@ class EnhetService(
 ) : IEnhetService {
     private val log = LoggerFactory.getLogger(this::class.java)
 
-    override fun hentEnheter(ident: String, currentToken: OidcToken): List<String> {
+    override fun hentEnheterForIdent(ident: String, currentToken: OidcToken): List<String> {
         return msGraphClient.hentEnhetsgrupper(ident, currentToken).groups
             .map { it.name.removePrefix(ENHET_GROUP_PREFIX) }
     }
@@ -106,6 +106,12 @@ class EnhetService(
                     finnEnhetstilknytningForPerson(ident, relevanteIdenter, saksnummer, erFørstegangsbehandling)
                 }
             }
+        }
+    }
+
+    fun hentEnheterMedNavn(): Map<String, String> {
+        return norgKlient.hentEnheter().entries.associate { (kode, norgNavn) ->
+            kode to (Enhet.entries.find { it.kode == kode }?.visningsnavn ?: norgNavn)
         }
     }
 

--- a/app/src/main/kotlin/no/nav/aap/oppgave/hent/HentOppgaveAPI.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/hent/HentOppgaveAPI.kt
@@ -68,7 +68,6 @@ fun NormalOpenAPIRoute.hentOppgaveVisningsinformasjonApi(
                 OppgaveRepository(connection),
                 MarkeringRepository(connection),
                 enhetService,
-                norgGateway
             ).hentAktivOppgave(request)
         }
 

--- a/app/src/main/kotlin/no/nav/aap/oppgave/hent/HentOppgaveEnhetAPI.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/hent/HentOppgaveEnhetAPI.kt
@@ -34,7 +34,6 @@ fun NormalOpenAPIRoute.hentOppgaveEnhetApi(
             OppgaveRepository(connection),
             MarkeringRepository(connection),
             enhetService,
-            norgGateway,
         ).hentOppgaveEnhetListe(behandlingReferanse)
     }
 

--- a/app/src/main/kotlin/no/nav/aap/oppgave/oppgaveliste/MineOppgaverAPI.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/oppgaveliste/MineOppgaverAPI.kt
@@ -35,7 +35,6 @@ fun NormalOpenAPIRoute.mineOppgaverApi(
                     OppgaveRepository(connection),
                     MarkeringRepository(connection),
                     enhetService,
-                    norgGateway
                 ).hentMineOppgaver(
                     ident = ident(),
                     kunPaaVent = req.kunPaaVent,

--- a/app/src/main/kotlin/no/nav/aap/oppgave/oppgaveliste/OppgavelisteAPI.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/oppgaveliste/OppgavelisteAPI.kt
@@ -50,7 +50,6 @@ fun NormalOpenAPIRoute.oppgavelisteApi(
                     OppgavelisteService(
                         oppgaveRepository = OppgaveRepository(connection),
                         markeringRepository = MarkeringRepository(connection),
-                        norgGateway = norgGateway,
                         enhetService = enhetService,
                     ).hentOppgaverMedTilgang(
                         request.utvidetFilter,

--- a/app/src/main/kotlin/no/nav/aap/oppgave/oppgaveliste/OppgavelisteService.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/oppgaveliste/OppgavelisteService.kt
@@ -10,7 +10,6 @@ import no.nav.aap.oppgave.OppgaveRepository.FinnOppgaverDto
 import no.nav.aap.oppgave.enhet.EnhetService
 import no.nav.aap.oppgave.enhet.OppgaveEnhetDto
 import no.nav.aap.oppgave.filter.Filter
-import no.nav.aap.oppgave.klienter.norg.INorgGateway
 import no.nav.aap.oppgave.liste.OppgaveSorteringFelt
 import no.nav.aap.oppgave.liste.OppgaveSorteringFelt.TILBAKEKREVINGS_BELOP
 import no.nav.aap.oppgave.liste.OppgaveSorteringRekkefølge
@@ -30,7 +29,6 @@ class OppgavelisteService(
     private val oppgaveRepository: OppgaveRepository,
     private val markeringRepository: MarkeringRepository,
     private val enhetService: EnhetService,
-    private val norgGateway: INorgGateway,
     private val unleashService: IUnleashService = UnleashServiceProvider.provideUnleashService(),
 ) {
     fun søkEtterOppgaver(søketekst: String): List<Oppgave> {
@@ -65,7 +63,7 @@ class OppgavelisteService(
             )
         }
     }
-
+    
     fun hentOppgaverMedTilgang(
         utvidetFilter: UtvidetOppgavelisteFilter?,
         enheter: Set<String>,
@@ -111,7 +109,7 @@ class OppgavelisteService(
             kunLedigeOppgaver = kunLedigeOppgaver,
             utvidetFilter = utvidetFilter,
             sortBy = aktivSortering,
-            enheterMedNavn = norgGateway.hentEnheter().takeIf { filter.navn == "Kvalitetssikrer" }.orEmpty(),
+            enheterMedNavn = enhetService.hentEnheterMedNavn().takeIf { filter.navn == "Kvalitetssikrer" }.orEmpty(),
             hastemarkeringerFørst = hastemarkeringerFørst
         )
 
@@ -189,7 +187,7 @@ class OppgavelisteService(
         ident: String
     ): List<Oppgave> {
         val oppgaverFiltrertForKode7 = sjekkTilgangTilFortroligAdresse(enhetService, ident, token, this)
-        val enhetsGrupper = enhetService.hentEnheter(ident, token)
+        val enhetsGrupper = enhetService.hentEnheterForIdent(ident, token)
         return oppgaverFiltrertForKode7
             .asSequence()
             .filter { it.enhetForKø in enhetsGrupper }

--- a/app/src/main/kotlin/no/nav/aap/oppgave/server/App.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/server/App.kt
@@ -155,7 +155,7 @@ internal fun Application.server(dbConfig: DbConfig, prometheus: PrometheusMeterR
                 hentFilterApi(dataSource, prometheus)
                 // Enheter
                 enhetStatus(dataSource)
-                hentEnhetApi(enhetService, norgGateway, prometheus)
+                hentEnhetApi(enhetService, prometheus)
                 nayEnhetForPerson(enhetService, prometheus)
                 synkroniserEnhetPåOppgaveApi(dataSource, enhetService, prometheus)
                 // Motor-API

--- a/app/src/main/kotlin/no/nav/aap/oppgave/søk/SøkApi.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/søk/SøkApi.kt
@@ -45,7 +45,6 @@ fun NormalOpenAPIRoute.søkApi(
                     OppgaveRepository(connection),
                     MarkeringRepository(connection),
                     enhetService,
-                    norgGateway
                 ).søkEtterOppgaver(søketekst)
             }
 

--- a/app/src/main/kotlin/no/nav/aap/oppgave/tildel/TildelOppgaveAPI.kt
+++ b/app/src/main/kotlin/no/nav/aap/oppgave/tildel/TildelOppgaveAPI.kt
@@ -85,7 +85,6 @@ fun NormalOpenAPIRoute.tildelOppgaveApi(
                 OppgaveRepository(connection),
                 MarkeringRepository(connection),
                 enhetService,
-                norgGateway
             ).hentAktivOppgave(request)
         }
 

--- a/app/src/test/kotlin/no/nav/aap/oppgave/enhet/EnhetServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/oppgave/enhet/EnhetServiceTest.kt
@@ -62,7 +62,7 @@ class EnhetServiceTest {
             ), NorgGatewayMock()
         )
 
-        val res = service.hentEnheter(
+        val res = service.hentEnheterForIdent(
             "xxx",
             OidcToken(AzureTokenGen("behandlingsflyt", "behandlingsflyt").generate(false, emptyList()))
         )
@@ -756,6 +756,24 @@ class EnhetServiceTest {
         assertThat(utledetEnhet.enhet).isEqualTo(ENHET_NAV_LØRENSKOG)
         assertThat(utledetEnhet.oppfølgingsenhet).isEqualTo("0220")
 
+    }
+
+    @Test
+    fun `Skal overstyre enhetsnavn for NAY Romerike`() {
+        val norgGateway = NorgGatewayMock.medRespons(
+            enhetsNavnRespons = mapOf("4402" to "Nav arbeid og ytelser Romerike")
+        )
+        val service = EnhetService(
+            graphGateway, pdlGateway, nomGateway, OppfølgingsenhetService(
+                dataSource,
+                VeilarbarenaGatewayMock()
+            ), norgGateway
+        )
+
+        val utledetEnhet = service.hentEnheterMedNavn()
+        
+        assertThat(utledetEnhet[Enhet.NAY_UTLAND.kode]).isNotNull()
+        assertThat(utledetEnhet[Enhet.NAY_UTLAND.kode]).isEqualTo("Nav arbeid og ytelser Utland")
     }
 
     companion object {

--- a/app/src/test/kotlin/no/nav/aap/oppgave/enhet/EnhetServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/oppgave/enhet/EnhetServiceTest.kt
@@ -761,7 +761,10 @@ class EnhetServiceTest {
     @Test
     fun `Skal overstyre enhetsnavn for NAY Romerike`() {
         val norgGateway = NorgGatewayMock.medRespons(
-            enhetsNavnRespons = mapOf("4402" to "Nav arbeid og ytelser Romerike")
+            enhetsNavnRespons = mapOf(
+                "4402" to "Nav arbeid og ytelser Romerike",
+                "4491" to "Nav arbeid og ytelser"
+            )
         )
         val service = EnhetService(
             graphGateway, pdlGateway, nomGateway, OppfølgingsenhetService(
@@ -771,9 +774,14 @@ class EnhetServiceTest {
         )
 
         val utledetEnhet = service.hentEnheterMedNavn()
-        
+
         assertThat(utledetEnhet[Enhet.NAY_UTLAND.kode]).isNotNull()
         assertThat(utledetEnhet[Enhet.NAY_UTLAND.kode]).isEqualTo("Nav arbeid og ytelser Utland")
+
+        assertThat(utledetEnhet[Enhet.NAY.kode]).isNotNull()
+        assertThat(utledetEnhet[Enhet.NAY.kode])
+            .describedAs("Skal bruke norg-navn dersom ingen overstyring")
+            .isEqualTo("Nav arbeid og ytelser")
     }
 
     companion object {

--- a/app/src/test/kotlin/no/nav/aap/oppgave/oppdater/OppdaterOppgaveServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/oppgave/oppdater/OppdaterOppgaveServiceTest.kt
@@ -1706,7 +1706,7 @@ class OppdaterOppgaveServiceTest {
     private val ENHET_NAV_ASKER = "0220"
     val enhetService = object : IEnhetService {
 
-        override fun hentEnheter(ident: String, currentToken: OidcToken): List<String> {
+        override fun hentEnheterForIdent(ident: String, currentToken: OidcToken): List<String> {
             TODO("Not yet implemented")
         }
 


### PR DESCRIPTION
* Sett visningsnavn for Nav arbeid og ytelser Romerike til Nay arbeid og ytelser Utland slik at det er tydelig for saksbehandler at man jobber på utenlandssaker