### PR TITLE
chore: add systemkatalog.nav.no/system label to nais manifest

### DIFF
--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     team: aap
     sub: oppgave
-    systemkatalog.nav.no/system: TE-496
+    systemkatalog.nav.no/system: SK-268
 
 spec:
   ingresses:

--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     team: aap
     sub: oppgave
+    systemkatalog.nav.no/system: TE-496
 
 spec:
   ingresses:


### PR DESCRIPTION
Adds the `systemkatalog.nav.no/system: TE-496` label to the nais Application manifest so this app is registered in systemkatalog.nav.no.